### PR TITLE
perf(frontend): make the first press of Start paint immediately

### DIFF
--- a/docs/design/09-school-theming.md
+++ b/docs/design/09-school-theming.md
@@ -110,3 +110,63 @@ The nudge label originally set `font-semibold` in the base class list and
 Tailwind's own emission order decided the winner, and semibold silently won. Put
 competing utilities in the branches only, never one in the base and one in the
 branch.
+
+## The default-blue flash on a hard load, and why the theme is now server-rendered
+
+Picking U of A themes the site green. Refreshing on the number screen showed the
+whole page in the default blue for a moment, then it faded to green.
+
+The provider is the reason. It applies its tokens by writing inline custom
+properties onto `<html>` from a `useEffect`, and an effect cannot run until React
+has hydrated. Its state also starts at `null`, and it lives in the root layout,
+which has no way to read `?school=`. So the sequence on a hard load of
+`/onboarding?school=ualberta` was:
+
+1. server sends HTML with no theme tokens, so the browser paints the default blue
+2. React hydrates
+3. the wizard's effect calls `setSchool("ualberta")`
+4. the provider's effect writes the green tokens
+
+Between 1 and 4 the page is blue, and step 4 arrives inside the 620ms
+`theme-shift` window, so it did not even swap cleanly — it *faded*, which is what
+made a one-frame problem impossible to miss.
+
+**The fix is to send the tokens as a stylesheet.** `themeCss` in
+`components/theme/themeVars.ts` renders the same token set as CSS text, and
+`OnboardingFrame` emits it as a `<style>` when the page knows the school. The
+first paint is then already green and the provider's effect changes nothing when
+it arrives.
+
+Three details that make it hold:
+
+**`themeVars` moved out of `SchoolTheme.tsx` into its own module.** A server
+component cannot call a function it imports from a `"use client"` file — it gets
+a client reference, not the function. The shared module is what lets the server
+stylesheet and the client provider derive from one implementation instead of two
+that drift.
+
+**The selector is `:root:root`, not `:root`.** Tailwind's default palette is a
+plain `:root` block in the linked stylesheet. Equal specificity would leave the
+winner up to document order, which happens to work today and would break
+silently the day React decided to hoist this `<style>` into the head. Doubling
+the selector wins on specificity instead, which is not order-dependent. It still
+loses to the provider's *inline* properties, which is correct: those are what a
+student switching schools without a reload updates.
+
+**The OAuth callback carries `?school=` now.** It always knew the school and was
+dropping it, so the return leg from Google landed unthemed. The other source for
+it is the user document, and reading that costs the two network calls
+[16](16-onboarding-entry-cost.md) deliberately keeps below the Suspense boundary.
+
+`theme-shift` is also no longer added on the provider's first effect run. Nothing
+is switching at mount, and opening a 620ms window where every element on the page
+transitions its colours is exactly how the old flash became a fade.
+
+`loading.tsx` renders the frame with no school and therefore no `<style>`, which
+is fine and not worth fixing: it is only ever shown during a client-side
+navigation, and by then the provider has already themed the document.
+
+Values reaching that stylesheet come from `data/schools.ts`, which is ours and
+committed — an unknown `?school=` fails `getSchool` and yields no style at all.
+Keep it that way: a school colour that ever came from a URL or a form would need
+escaping before it reached a `<style>`.

--- a/docs/design/16-onboarding-entry-cost.md
+++ b/docs/design/16-onboarding-entry-cost.md
@@ -1,0 +1,103 @@
+# 16. The pause on the way into onboarding
+
+A student picks their school on the landing page, presses *i'm ready to start*,
+and nothing happens for a moment. Then the setup card appears. It only ever
+happens on the first press; going back and forth afterwards is instant.
+
+That "only the first time" is the tell. Everything the second press reuses, the
+first press had to fetch, and it fetched all of it before drawing anything.
+
+## What the first press was actually paying for
+
+Two costs, stacked, with nothing on screen while they ran.
+
+**The route could not be prefetched.** `/onboarding` is `force-dynamic`, and
+Next prefetches a dynamic route only as far as its nearest loading boundary.
+There was no `loading.tsx`, so there was no boundary, so there was nothing to
+prefetch. Measured against a production build, the prefetch the hero's `<Link>`
+fires when it scrolls into view returned **186 bytes** and named **zero** chunks
+to preload. The router learned nothing and cached nothing.
+
+**So the click paid for everything at once.** A cold RSC round trip to the
+server, plus every byte of JavaScript the route needed and the browser had never
+seen: **185 kB raw, about 57 kB gzipped**. Roughly 40 kB gzipped of that was the
+Firebase Auth SDK, statically imported by the wizard and therefore sitting in
+the chunk that has to be parsed before the page can hydrate — despite doing
+nothing at all until the student presses *Text me a code*.
+
+And on the server, the page awaited `getSession()` and `getUserByAuthUid()` in
+its own function body, above the `<Suspense>` boundary. A boundary with nothing
+suspending beneath it streams nothing, so the response could not begin until
+Firebase Admin had verified the session cookie (a network call: `checkRevoked`
+is on, see [15](15-firebase-auth.md)) and Firestore had answered a query. Two
+round trips before the first byte.
+
+Locally none of this shows up: the RSC render is about 4 ms and the chunks come
+off localhost. It is real on a phone on campus wifi, which is where it was seen.
+
+## The three changes
+
+**`app/onboarding/loading.tsx`.** The load-bearing one. Its purpose is not
+politeness, it is giving the prefetcher a boundary to stop at. With it in place
+the same prefetch returns **10.3 kB** of real card markup and names **five**
+chunks to preload, so the route's JavaScript is already in the browser by the
+time the student clicks — fetched while they were still choosing a school.
+
+**The session reads moved below the boundary.** `page.tsx` is synchronous again;
+an async child does the two reads. The frame and the card flush immediately and
+the wizard arrives when Firebase and Firestore answer.
+
+**The Firebase Auth SDK is imported on demand.** `lib/firebaseClient.ts` now
+pulls `firebase/app` and `firebase/auth` through a dynamic `import()` instead of
+a static one. `warmPhoneAuth()` starts that fetch from an effect once the wizard
+has mounted, so it is off the hydration path but has landed long before anyone
+has finished typing ten digits.
+
+Measured on a production build:
+
+| | before | after |
+| --- | --- | --- |
+| Prefetch payload | 186 B, 0 chunks | 10.3 kB, 5 chunks |
+| New JS on the `/` → `/onboarding` hop | 185 kB raw / 57 kB gz | 69 kB raw / 21 kB gz |
+| `/onboarding` route JS | 56.5 kB | 16.6 kB |
+| `/onboarding` first load JS | 167 kB | 132 kB |
+
+## The rules this leaves behind
+
+**`components/onboarding/shell.tsx` must not become a client component.** The
+card, the progress bar and the page frame live there precisely so `loading.tsx`
+can render them on the server. A hook or a browser API anywhere in that file
+forces a `"use client"` onto it, which drags the entire wizard bundle into the
+loading boundary and silently undoes the fix. There is nothing in the build
+output that would flag it.
+
+**Nothing dynamic in the `loading.tsx` subtree.** Reading cookies or headers
+there makes the boundary unprefetchable again, which is the same failure in a
+different disguise.
+
+**The skeleton is not a placeholder for the header.** The card, the back arrow,
+the line of encouragement and the progress bar in the fallback are the real
+components with real content, because none of them depend on the session. Only
+the body below is greyed. That is what makes the swap invisible: nothing moves
+when the wizard lands, it just fills in.
+
+The bar opens on phase 0 in the fallback, because a student arriving with no
+`?school=` still has a school to pick. One who arrives with a school is moved to
+phase 1 by the wizard, which is the bar animating forwards — the direction it
+should move anyway, rather than a correction.
+
+## One thing checked and deliberately not changed
+
+`useSearchParams()` inside a Suspense boundary is documented to fall back to
+client rendering on a *statically* rendered route, which would have meant the
+server drawing the school picker and hydration immediately replacing it with the
+number screen — a visible swap on every hard load, including the return leg from
+Google's consent screen.
+
+It does not happen here. `force-dynamic` takes the route out of that case, and
+a production build serving `/onboarding?school=tmu` renders `What is your
+number?` and the school's name in the HTML. The hook stays. (The check that
+first suggested otherwise used `?school=uwo`, which is not a school in
+`data/schools.ts`; `getSchool` returned undefined and the picker was the correct
+response. Worth knowing when testing this route by hand: an unknown id fails
+silently and looks exactly like the bug.)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -22,6 +22,7 @@ Read these before changing something that looks arbitrary. Most of it is not.
 | [13 Connect step scenes](13-connect-scenes.md) | The two loops that replaced the scope list, and what the sealed envelope does not claim |
 | [14 Attention and nudges](14-attention-and-nudges.md) | The CTA pulse, why the hero gets a different cue, and the 30 second start card |
 | [15 Firebase Auth](15-firebase-auth.md) | Why the login is a phone number, the two ids and the seam between them, the access switches |
+| [16 Onboarding entry cost](16-onboarding-entry-cost.md) | The pause on the first press of Start, why the route could not be prefetched, and the rules that keep it fixed |
 
 ## Ground rules that apply everywhere
 

--- a/src/frontend/app/onboarding/callback/route.ts
+++ b/src/frontend/app/onboarding/callback/route.ts
@@ -26,8 +26,27 @@ import { recordGoogleConnection } from "@/lib/users";
 
 export const dynamic = "force-dynamic";
 
-function back(request: NextRequest, params: Record<string, string>) {
+/**
+ * Back to the wizard, carrying the school.
+ *
+ * The school is not decoration on this URL. The onboarding page renders itself
+ * in the school's colours from `?school=`, and that is the only way it can know
+ * them before hydration -- the alternative source is the user document, which
+ * costs the two network calls the page deliberately does not make above its
+ * Suspense boundary. Without it the return leg from Google lands on a page
+ * painted in the default blue that repaints a moment later.
+ *
+ * `pending` is gone by the time some of these fire, so it is optional and the
+ * wizard still falls back to the school on the user document. One frame of the
+ * wrong colour on a path that already failed is not worth more than this.
+ */
+function back(
+  request: NextRequest,
+  params: Record<string, string>,
+  schoolId?: string | null,
+) {
   const url = new URL("/onboarding", request.nextUrl.origin);
+  if (schoolId) url.searchParams.set("school", schoolId);
   for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
   return NextResponse.redirect(url);
 }
@@ -42,14 +61,16 @@ export async function GET(request: NextRequest) {
   const oauthError = query.get("error");
   if (oauthError) {
     // access_denied is a student clicking Cancel, not a fault.
-    return back(request, {
-      error: oauthError === "access_denied" ? "cancelled" : "google",
-    });
+    return back(
+      request,
+      { error: oauthError === "access_denied" ? "cancelled" : "google" },
+      pending?.schoolId,
+    );
   }
 
   const code = query.get("code");
   const state = query.get("state");
-  if (!code || !state) return back(request, { error: "incomplete" });
+  if (!code || !state) return back(request, { error: "incomplete" }, pending?.schoolId);
 
   // CSRF. An attacker can make a browser hit this URL with their own code, but
   // not with a state matching the signed cookie we set moments earlier.
@@ -59,7 +80,7 @@ export async function GET(request: NextRequest) {
   // Auth this route had no prior identity to check against and simply believed
   // whatever the connector returned.
   const session = await getSession();
-  if (!session) return back(request, { error: "signin" });
+  if (!session) return back(request, { error: "signin" }, pending.schoolId);
 
   const school = getSchool(pending.schoolId);
   if (!school || school.status !== "live") return back(request, { error: "school" });
@@ -76,17 +97,17 @@ export async function GET(request: NextRequest) {
       // Body may carry a Google error; it is not safe to show a student and not
       // useful to them either. Log it, show them something they can act on.
       console.error("connector /auth/callback failed", res.status, await res.text());
-      return back(request, { error: "exchange" });
+      return back(request, { error: "exchange" }, school.id);
     }
     payload = await res.json();
   } catch (err) {
     console.error("connector /auth/callback unreachable", err);
-    return back(request, { error: "unreachable" });
+    return back(request, { error: "unreachable" }, school.id);
   }
 
   const userId = payload.user_id;
   const email = payload.email?.toLowerCase();
-  if (!userId || !email) return back(request, { error: "exchange" });
+  if (!userId || !email) return back(request, { error: "exchange" }, school.id);
 
   /*
    * School eligibility, and this is the check that actually enforces it.
@@ -97,7 +118,7 @@ export async function GET(request: NextRequest) {
    * address in this flow that is proven, so it is the only one worth testing.
    */
   if (!email.endsWith(`@${school.emailDomain}`)) {
-    return back(request, { error: "domain" });
+    return back(request, { error: "domain" }, school.id);
   }
 
   /*
@@ -110,7 +131,7 @@ export async function GET(request: NextRequest) {
    * silently adopting the second is the wrong way to resolve that.
    */
   if (pending.email && email !== pending.email) {
-    return back(request, { error: "mismatch" });
+    return back(request, { error: "mismatch" }, school.id);
   }
 
   // The write that binds the phone identity to the Google one. Everything
@@ -124,5 +145,5 @@ export async function GET(request: NextRequest) {
     phoneNumber: session.phone,
   });
 
-  return back(request, { connected: "1" });
+  return back(request, { connected: "1" }, school.id);
 }

--- a/src/frontend/app/onboarding/loading.tsx
+++ b/src/frontend/app/onboarding/loading.tsx
@@ -1,0 +1,26 @@
+import { OnboardingFrame, WizardSkeleton } from "@/components/onboarding/shell";
+
+/**
+ * The reason this file exists is prefetching, not politeness.
+ *
+ * /onboarding is force-dynamic, and Next prefetches a dynamic route only as far
+ * as its nearest loading boundary. Without this file there was no boundary, so
+ * the prefetch fired by the hero's "i'm ready to start" link came back with 186
+ * bytes and the router had nothing cached and no idea which chunks the route
+ * needed. The click then paid for the server round trip and ~57 kB gzipped of
+ * cold JavaScript at once, which is the pause a student sees exactly once.
+ *
+ * With it, the same prefetch returns this card and preloads the route's chunks
+ * while the student is still choosing a school, so the click paints immediately.
+ *
+ * Nothing here reads the session, and it must stay that way: anything dynamic in
+ * this subtree makes the boundary unprefetchable again and quietly restores the
+ * stutter.
+ */
+export default function OnboardingLoading() {
+  return (
+    <OnboardingFrame>
+      <WizardSkeleton />
+    </OnboardingFrame>
+  );
+}

--- a/src/frontend/app/onboarding/page.tsx
+++ b/src/frontend/app/onboarding/page.tsx
@@ -1,8 +1,7 @@
 import type { Metadata } from "next";
 import { Suspense } from "react";
 import { OnboardingWizard } from "@/components/onboarding/OnboardingWizard";
-import { BuiltBy } from "@/components/site/BuiltBy";
-import { Container } from "@/components/ui/primitives";
+import { OnboardingFrame, WizardSkeleton } from "@/components/onboarding/shell";
 import { getSession } from "@/lib/authSession";
 import { getUserByAuthUid } from "@/lib/users";
 
@@ -16,7 +15,33 @@ export const metadata: Metadata = {
 // Reads the session cookie, so it cannot be statically rendered.
 export const dynamic = "force-dynamic";
 
-export default async function OnboardingPage() {
+/**
+ * The page itself is synchronous now, and that is the point.
+ *
+ * It used to await getSession() and getUserByAuthUid() in this function body,
+ * above the Suspense boundary. A boundary with nothing suspending under it
+ * streams nothing, so the browser held on the previous page until Firebase
+ * Admin had verified the session cookie -- a network call, because checkRevoked
+ * is on -- and Firestore had answered a query. Two round trips before the first
+ * byte, on a route the router could not prefetch either.
+ *
+ * With the reads moved into a child below the boundary, the frame and the card
+ * flush immediately and the wizard arrives when they finish. loading.tsx is the
+ * other half: it is what makes the route prefetchable at all.
+ * See docs/design/16-onboarding-entry-cost.md.
+ */
+export default function OnboardingPage() {
+  return (
+    <OnboardingFrame>
+      {/* Also the boundary useSearchParams needs inside the wizard. */}
+      <Suspense fallback={<WizardSkeleton />}>
+        <SignedInWizard />
+      </Suspense>
+    </OnboardingFrame>
+  );
+}
+
+async function SignedInWizard() {
   // The wizard is a client component and the session cookie is httpOnly, so
   // what has been proven has to be handed down from here. A student returning
   // from the Google consent screen lands on this page, not on a fresh one.
@@ -37,35 +62,5 @@ export default async function OnboardingPage() {
       }
     : null;
 
-  return (
-    <div className="relative min-h-dvh bg-paper">
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-x-0 top-0 h-[28rem] overflow-hidden"
-      >
-        <div className="grain-grid absolute inset-0 [mask-image:linear-gradient(to_bottom,black,transparent)]" />
-        <div className="absolute -left-24 -top-32 h-[26rem] w-[26rem] rounded-full bg-sky-200/50 blur-[110px]" />
-      </div>
-
-      <Container className="relative py-12 sm:py-16">
-        {/* useSearchParams needs a boundary on a statically rendered route. */}
-        <Suspense fallback={<div className="min-h-[26rem]" />}>
-          <OnboardingWizard connected={account} />
-        </Suspense>
-
-        {/* A "trouble getting in? email chim@wopara.com or read the privacy
-            policy" line used to sit here. The privacy policy and terms are
-            still linked from the consent step, which is the screen where they
-            actually matter. The support address is not on this page any more,
-            so a student who cannot get in has nowhere to write from here.
-
-            Everything above this is mechanism: fields, scopes, a progress bar.
-            Three faces at the bottom of the page that asks for a school login
-            is the cheapest way to say a person is behind it. */}
-        <div className="mt-12">
-          <BuiltBy />
-        </div>
-      </Container>
-    </div>
-  );
+  return <OnboardingWizard connected={account} />;
 }

--- a/src/frontend/app/onboarding/page.tsx
+++ b/src/frontend/app/onboarding/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Suspense } from "react";
 import { OnboardingWizard } from "@/components/onboarding/OnboardingWizard";
 import { OnboardingFrame, WizardSkeleton } from "@/components/onboarding/shell";
+import { getSchool } from "@/data/schools";
 import { getSession } from "@/lib/authSession";
 import { getUserByAuthUid } from "@/lib/users";
 
@@ -30,9 +31,24 @@ export const dynamic = "force-dynamic";
  * other half: it is what makes the route prefetchable at all.
  * See docs/design/16-onboarding-entry-cost.md.
  */
-export default function OnboardingPage() {
+export default async function OnboardingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ school?: string }>;
+}) {
+  /*
+   * The only await left above the boundary, and it is free: searchParams is
+   * already in hand by the time this runs, so it resolves in a microtask. It is
+   * not a reason to move the session reads back up here -- those are two network
+   * calls, which is the whole reason they sit below.
+   *
+   * It buys the school, which the frame needs in order to render the page in
+   * that school's colours from the server rather than after hydration.
+   */
+  const { school } = await searchParams;
+
   return (
-    <OnboardingFrame>
+    <OnboardingFrame school={school ? getSchool(school) : null}>
       {/* Also the boundary useSearchParams needs inside the wizard. */}
       <Suspense fallback={<WizardSkeleton />}>
         <SignedInWizard />

--- a/src/frontend/components/onboarding/OnboardingWizard.tsx
+++ b/src/frontend/components/onboarding/OnboardingWizard.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/onboarding/connectScenes";
 import { Choice, Field, TextInput, formatPhone } from "@/components/onboarding/fields";
 import { PhoneVerifyScene } from "@/components/onboarding/phoneScenes";
+import { Shell } from "@/components/onboarding/shell";
 import { LogoMark } from "@/components/brand/LogoMark";
 import { useSchoolTheme } from "@/components/theme/SchoolTheme";
 import { ACCESS_ITEMS, defaultAccess, type AccessKey } from "@/data/access";
@@ -28,6 +29,7 @@ import {
   phoneErrorMessage,
   sendVerificationCode,
   signOutClient,
+  warmPhoneAuth,
   type PendingVerification,
 } from "@/lib/firebaseClient";
 
@@ -62,7 +64,7 @@ import {
  * Google step says so in as many words before sending them.
  */
 
-/** The heading on each screen. Four screens, but see PHASES below. */
+/** The heading on each screen. Four screens, but three PHASES: see shell.tsx. */
 const STEP_TITLES = [
   "What is your number?",
   "Connect your school account",
@@ -70,29 +72,9 @@ const STEP_TITLES = [
   "Choose what it can touch",
 ];
 
-/**
- * What the student is told they are doing, which is not the same as the number
- * of screens.
- *
- * Four screens were shown as four numbered steps in a rail down the side, plus
- * the school picker before them, so the flow announced itself as five things to
- * get through before anything happened. It is three: pick a school, sign in,
- * confirm your details. The two sign-in screens are one job with a technical
- * seam in the middle, and the same is true of the last two.
- *
- * Counting this way also means the school picker is worth something. It was
- * unnumbered, so a student arriving at screen two had done a third of the work
- * and was told they were at step one of four.
- */
-/**
- * The last one is called "Welcome gift" rather than "Your details" because the
- * screen it labels is where a student finds out Classistant is free for the
- * whole beta. Naming the reward instead of the paperwork is the difference
- * between a third step and a reason to finish.
- */
-const PHASES = ["Pick your school", "Log in", "Welcome gift"];
-
-/** Screens 0 to 2 are all logging in; the last one is the reward. */
+/** Screens 0 to 2 are all logging in; the last one is the reward. The three
+ *  phases they map onto, and the card that draws them, live in
+ *  components/onboarding/shell.tsx so the loading boundary can render them too. */
 const phaseForStep = (step: number) => (step <= 2 ? 1 : 2);
 
 /**
@@ -145,6 +127,17 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
   useEffect(() => {
     if (school && themedSchool?.id !== school.id) setSchool(school.id);
   }, [school, themedSchool, setSchool]);
+
+  /*
+   * Start fetching the Firebase Auth SDK, which is no longer in this page's
+   * bundle (see lib/firebaseClient.ts for why it was taken out).
+   *
+   * In an effect rather than at module scope, so it begins after the page has
+   * painted and hydrated instead of competing with the chunks that do that. A
+   * student still has to read the screen and type ten digits before anything
+   * needs it, which is far longer than the fetch takes.
+   */
+  useEffect(warmPhoneAuth, []);
 
   /*
    * Where to open, from what the server already proved.
@@ -1065,129 +1058,6 @@ function HiddenState({ step, values }: { step: number; values: Record<string, st
           <input key={key} type="hidden" name={key} value={value} />
         ))}
     </>
-  );
-}
-
-function Shell({
-  phase,
-  school,
-  children,
-}: {
-  /** Index into PHASES. Also the count of phases already finished. */
-  phase: number;
-  school?: School;
-  children: React.ReactNode;
-}) {
-  return (
-    // One column. The 17rem rail that used to sit on the left held a logo and a
-    // school name, and once the numbered steps came out of it there was not
-    // enough left to justify a quarter of the viewport. Both survivors moved
-    // into the card's own top row, so the form gets the full width.
-    <div className="mx-auto w-full max-w-[58rem] rounded-[1.4rem] bg-white p-6 shadow-soft ring-1 ring-line sm:p-9">
-      {/* The wordmark used to sit here. It said where you were, which the
-          student already knows, and said nothing about whether to keep going.
-          Only the arrow navigates: making the whole row a link would mean the
-          line of encouragement is also the way out of the flow. */}
-      <div className="mb-7 flex items-center justify-between gap-4">
-        <div className="flex min-w-0 items-center gap-2.5">
-          <Link
-            href="/"
-            aria-label="Back to the home page"
-            className="grid h-8 w-8 shrink-0 place-items-center rounded-full text-body-soft ring-1 ring-line transition-colors hover:bg-sky-50 hover:text-ink-900"
-          >
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-              <path
-                d="M9.75 3.5 5.25 8l4.5 4.5"
-                stroke="currentColor"
-                strokeWidth="1.9"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          </Link>
-          <span className="truncate font-display text-[1.05rem] font-extrabold tracking-[-0.01em] text-ink-900">
-            You&rsquo;re almost done!
-          </span>
-        </div>
-
-        {school ? (
-          <span className="hidden truncate text-[0.85rem] font-semibold text-body-soft sm:block">
-            {school.name}
-          </span>
-        ) : null}
-      </div>
-
-      <Progress phase={phase} />
-      {children}
-    </div>
-  );
-}
-
-/**
- * Three milestones and a bar, in place of the numbered rail.
- *
- * The fill is phases *finished*, so picking a school is worth a third before
- * the sign-in screen is even drawn. That is the honest reading and it is also
- * the encouraging one: nobody arrives at the second screen having earned zero.
- *
- * It follows that the last phase shows two thirds while you are working through
- * it, and only the finished screen would be full.
- */
-function Progress({ phase }: { phase: number }) {
-  // Fill to the middle of the phase you are in, not to the start of it. The
-  // labels are spread across the full width, so a bar that stopped at the start
-  // of "Log in" landed short of the word and read as not having got there yet.
-  // Half a phase in puts the end of the bar under the label it belongs to, and
-  // the flow feels quicker for it. It also never claims 100% before the last
-  // screen is done, which fill-the-whole-current-phase would.
-  const pct = ((phase + 0.5) / PHASES.length) * 100;
-
-  return (
-    <div className="mb-7">
-      <div className="flex items-baseline justify-between gap-3">
-        {PHASES.map((label, i) => (
-          <span
-            key={label}
-            className={cn(
-              "text-[0.68rem] uppercase tracking-[0.12em] transition-colors",
-              // The current phase has to be the loudest thing here. Finished
-              // phases were brand green, and green beat black: on the sign-in
-              // screen the eye landed on "Pick your school" and the page read
-              // as if that were where you still were. Done recedes to grey now
-              // and the bar carries the progress; only the current label is
-              // dark, and it is the only bold one.
-              //
-              // Competing utilities live in the branches only, never split
-              // between a base string and a branch: Tailwind resolves those by
-              // emission order, not by writing order.
-              i < phase
-                ? "font-semibold text-body-soft"
-                : i === phase
-                  ? "font-bold text-ink-900"
-                  : "font-semibold text-body-soft/55",
-            )}
-          >
-            {label}
-          </span>
-        ))}
-      </div>
-
-      <div
-        className="mt-2.5 h-1.5 overflow-hidden rounded-full bg-line"
-        role="progressbar"
-        aria-valuenow={phase}
-        aria-valuemin={0}
-        aria-valuemax={PHASES.length}
-        aria-label={`Step ${phase + 1} of ${PHASES.length}: ${PHASES[phase]}`}
-      >
-        {/* max() keeps a visible nub at the start rather than an empty track,
-            without overstating how far along a fresh arrival actually is. */}
-        <div
-          className="h-full rounded-full bg-brand-600 transition-[width] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]"
-          style={{ width: `max(${pct}%, 0.4rem)` }}
-        />
-      </div>
-    </div>
   );
 }
 

--- a/src/frontend/components/onboarding/shell.tsx
+++ b/src/frontend/components/onboarding/shell.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { BuiltBy } from "@/components/site/BuiltBy";
 import { Container } from "@/components/ui/primitives";
+import { themeCss } from "@/components/theme/themeVars";
 import { cn } from "@/lib/cn";
 import type { School } from "@/data/schools";
 
@@ -54,10 +55,38 @@ export const PHASES = ["Pick your school", "Log in", "Welcome gift"];
  * Shared by page.tsx and loading.tsx so the two paint identically. If the
  * loading boundary drew its own approximation of this, arriving content would
  * shift the card, which is a worse artefact than the pause it replaced.
+ *
+ * `school` exists only to paint it in that school's colours from the server.
+ * The theme is otherwise applied by SchoolThemeProvider in an effect, which
+ * cannot run until React has hydrated, so a hard load of
+ * /onboarding?school=ualberta drew the whole page in the default blue and then
+ * repainted it green a moment later. Emitting the tokens as a stylesheet the
+ * server sends means the first paint is already right and the effect changes
+ * nothing when it arrives.
+ *
+ * Optional because loading.tsx has no way to know the school -- it is rendered
+ * for a prefetch, before the request that carries ?school= exists. That is
+ * fine: the loading card is only ever shown during a client-side navigation,
+ * and by then the provider has already themed the document.
  */
-export function OnboardingFrame({ children }: { children: React.ReactNode }) {
+export function OnboardingFrame({
+  school,
+  children,
+}: {
+  school?: School | null;
+  children: React.ReactNode;
+}) {
+  const css = school ? themeCss(school) : null;
+
   return (
     <div className="relative min-h-dvh bg-paper">
+      {/* Ahead of everything it themes, and rendered as a plain <style> with no
+          `precedence` so React leaves it here rather than hoisting it into the
+          head. It has to lose to the provider's inline properties, which are
+          what a student picking a different school updates, and beat Tailwind's
+          default `:root` block, which themeCss's doubled selector handles. */}
+      {css ? <style dangerouslySetInnerHTML={{ __html: css }} /> : null}
+
       <div
         aria-hidden="true"
         className="pointer-events-none absolute inset-x-0 top-0 h-[28rem] overflow-hidden"

--- a/src/frontend/components/onboarding/shell.tsx
+++ b/src/frontend/components/onboarding/shell.tsx
@@ -1,0 +1,257 @@
+import Link from "next/link";
+import { BuiltBy } from "@/components/site/BuiltBy";
+import { Container } from "@/components/ui/primitives";
+import { cn } from "@/lib/cn";
+import type { School } from "@/data/schools";
+
+/**
+ * The furniture around the wizard: the page wash, the card, the progress bar.
+ *
+ * This is a plain module with no "use client" on purpose, even though the wizard
+ * that renders it is a client component. Everything here is static markup and a
+ * Link, so it costs nothing to run on the server, and being server-renderable is
+ * what lets app/onboarding/loading.tsx draw the exact same card while the real
+ * one is still being fetched.
+ *
+ * That matters more than it sounds. /onboarding is force-dynamic, and Next only
+ * prefetches a dynamic route as far as its nearest loading boundary. With no
+ * loading.tsx the prefetch returned 186 bytes of nothing, so clicking "i'm ready
+ * to start" paid for a server round trip AND ~57 kB gzipped of never-before-seen
+ * JavaScript before a single pixel moved. That pause is the stutter students see
+ * on their first arrival and never again.
+ * See docs/design/16-onboarding-entry-cost.md.
+ *
+ * So these components have exactly one hard rule: no hooks, no browser APIs,
+ * nothing that would force a "use client" onto this file. Adding one silently
+ * drags the whole wizard bundle into the loading boundary and undoes the fix.
+ */
+
+/**
+ * What the student is told they are doing, which is not the same as the number
+ * of screens.
+ *
+ * Four screens were shown as four numbered steps in a rail down the side, plus
+ * the school picker before them, so the flow announced itself as five things to
+ * get through before anything happened. It is three: pick a school, sign in,
+ * confirm your details. The two sign-in screens are one job with a technical
+ * seam in the middle, and the same is true of the last two.
+ *
+ * Counting this way also means the school picker is worth something. It was
+ * unnumbered, so a student arriving at screen two had done a third of the work
+ * and was told they were at step one of four.
+ *
+ * The last one is called "Welcome gift" rather than "Your details" because the
+ * screen it labels is where a student finds out Classistant is free for the
+ * whole beta. Naming the reward instead of the paperwork is the difference
+ * between a third step and a reason to finish.
+ */
+export const PHASES = ["Pick your school", "Log in", "Welcome gift"];
+
+/**
+ * The page around the card: background wash, container, and the faces at the
+ * bottom.
+ *
+ * Shared by page.tsx and loading.tsx so the two paint identically. If the
+ * loading boundary drew its own approximation of this, arriving content would
+ * shift the card, which is a worse artefact than the pause it replaced.
+ */
+export function OnboardingFrame({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative min-h-dvh bg-paper">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-0 top-0 h-[28rem] overflow-hidden"
+      >
+        <div className="grain-grid absolute inset-0 [mask-image:linear-gradient(to_bottom,black,transparent)]" />
+        <div className="absolute -left-24 -top-32 h-[26rem] w-[26rem] rounded-full bg-sky-200/50 blur-[110px]" />
+      </div>
+
+      <Container className="relative py-12 sm:py-16">
+        {children}
+
+        {/* A "trouble getting in? email chim@wopara.com or read the privacy
+            policy" line used to sit here. The privacy policy and terms are
+            still linked from the consent step, which is the screen where they
+            actually matter. The support address is not on this page any more,
+            so a student who cannot get in has nowhere to write from here.
+
+            Everything above this is mechanism: fields, scopes, a progress bar.
+            Three faces at the bottom of the page that asks for a school login
+            is the cheapest way to say a person is behind it. */}
+        <div className="mt-12">
+          <BuiltBy />
+        </div>
+      </Container>
+    </div>
+  );
+}
+
+export function Shell({
+  phase,
+  school,
+  children,
+}: {
+  /** Index into PHASES. Also the count of phases already finished. */
+  phase: number;
+  school?: School;
+  children: React.ReactNode;
+}) {
+  return (
+    // One column. The 17rem rail that used to sit on the left held a logo and a
+    // school name, and once the numbered steps came out of it there was not
+    // enough left to justify a quarter of the viewport. Both survivors moved
+    // into the card's own top row, so the form gets the full width.
+    <div className="mx-auto w-full max-w-[58rem] rounded-[1.4rem] bg-white p-6 shadow-soft ring-1 ring-line sm:p-9">
+      {/* The wordmark used to sit here. It said where you were, which the
+          student already knows, and said nothing about whether to keep going.
+          Only the arrow navigates: making the whole row a link would mean the
+          line of encouragement is also the way out of the flow. */}
+      <div className="mb-7 flex items-center justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-2.5">
+          <Link
+            href="/"
+            aria-label="Back to the home page"
+            className="grid h-8 w-8 shrink-0 place-items-center rounded-full text-body-soft ring-1 ring-line transition-colors hover:bg-sky-50 hover:text-ink-900"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path
+                d="M9.75 3.5 5.25 8l4.5 4.5"
+                stroke="currentColor"
+                strokeWidth="1.9"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </Link>
+          <span className="truncate font-display text-[1.05rem] font-extrabold tracking-[-0.01em] text-ink-900">
+            You&rsquo;re almost done!
+          </span>
+        </div>
+
+        {school ? (
+          <span className="hidden truncate text-[0.85rem] font-semibold text-body-soft sm:block">
+            {school.name}
+          </span>
+        ) : null}
+      </div>
+
+      <Progress phase={phase} />
+      {children}
+    </div>
+  );
+}
+
+/**
+ * Three milestones and a bar, in place of the numbered rail.
+ *
+ * The fill is phases *finished*, so picking a school is worth a third before
+ * the sign-in screen is even drawn. That is the honest reading and it is also
+ * the encouraging one: nobody arrives at the second screen having earned zero.
+ *
+ * It follows that the last phase shows two thirds while you are working through
+ * it, and only the finished screen would be full.
+ */
+function Progress({ phase }: { phase: number }) {
+  // Fill to the middle of the phase you are in, not to the start of it. The
+  // labels are spread across the full width, so a bar that stopped at the start
+  // of "Log in" landed short of the word and read as not having got there yet.
+  // Half a phase in puts the end of the bar under the label it belongs to, and
+  // the flow feels quicker for it. It also never claims 100% before the last
+  // screen is done, which fill-the-whole-current-phase would.
+  const pct = ((phase + 0.5) / PHASES.length) * 100;
+
+  return (
+    <div className="mb-7">
+      <div className="flex items-baseline justify-between gap-3">
+        {PHASES.map((label, i) => (
+          <span
+            key={label}
+            className={cn(
+              "text-[0.68rem] uppercase tracking-[0.12em] transition-colors",
+              // The current phase has to be the loudest thing here. Finished
+              // phases were brand green, and green beat black: on the sign-in
+              // screen the eye landed on "Pick your school" and the page read
+              // as if that were where you still were. Done recedes to grey now
+              // and the bar carries the progress; only the current label is
+              // dark, and it is the only bold one.
+              //
+              // Competing utilities live in the branches only, never split
+              // between a base string and a branch: Tailwind resolves those by
+              // emission order, not by writing order.
+              i < phase
+                ? "font-semibold text-body-soft"
+                : i === phase
+                  ? "font-bold text-ink-900"
+                  : "font-semibold text-body-soft/55",
+            )}
+          >
+            {label}
+          </span>
+        ))}
+      </div>
+
+      <div
+        className="mt-2.5 h-1.5 overflow-hidden rounded-full bg-line"
+        role="progressbar"
+        aria-valuenow={phase}
+        aria-valuemin={0}
+        aria-valuemax={PHASES.length}
+        aria-label={`Step ${phase + 1} of ${PHASES.length}: ${PHASES[phase]}`}
+      >
+        {/* max() keeps a visible nub at the start rather than an empty track,
+            without overstating how far along a fresh arrival actually is. */}
+        <div
+          className="h-full rounded-full bg-brand-600 transition-[width] duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]"
+          style={{ width: `max(${pct}%, 0.4rem)` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * What stands in for the wizard until it arrives.
+ *
+ * The card, the back arrow, the line of encouragement and the progress bar are
+ * the real ones, not placeholders -- none of them depend on the session, so
+ * there is no reason to fake them and then swap. Only the body below is greyed,
+ * and it is held at roughly the height of the first screen so the card does not
+ * jump when the form lands.
+ *
+ * The bar opens on phase 0 because a student arriving with no ?school still has
+ * a school to pick. One who arrives with one is moved to phase 1 by the wizard;
+ * that is a bar animating forward, which is the direction it should move
+ * anyway, rather than a correction.
+ *
+ * Deliberately not a shimmer. This is on screen for a few hundred milliseconds
+ * on a first visit and never again, and an animation that draws the eye to a
+ * blank rectangle makes the wait feel longer than a still one does.
+ */
+export function WizardSkeleton() {
+  return (
+    <Shell phase={0}>
+      <div aria-hidden="true" className="min-h-[24rem] animate-pulse motion-reduce:animate-none">
+        <div className="h-8 w-3/5 rounded-lg bg-line-soft" />
+        <div className="mt-7 grid items-center gap-5 sm:grid-cols-2">
+          <div className="flex flex-col gap-3">
+            <div className="h-5 w-11/12 rounded bg-line-soft" />
+            <div className="h-4 w-full rounded bg-line-soft/70" />
+            <div className="h-4 w-10/12 rounded bg-line-soft/70" />
+            <div className="h-4 w-7/12 rounded bg-line-soft/70" />
+          </div>
+          <div className="h-[12.5rem] rounded-[1.1rem] bg-paper ring-1 ring-line" />
+        </div>
+        <div className="mt-5 h-[3.4rem] rounded-xl bg-line-soft/60" />
+        <div className="mt-9 border-t border-line-soft pt-6">
+          <div className="ml-auto h-12 w-40 rounded-xl bg-line-soft" />
+        </div>
+      </div>
+
+      {/* The visible card says nothing while it is empty, so the wait is
+          announced here instead of being silent to a screen reader. */}
+      <p className="sr-only" role="status">
+        Loading your setup.
+      </p>
+    </Shell>
+  );
+}

--- a/src/frontend/components/theme/SchoolTheme.tsx
+++ b/src/frontend/components/theme/SchoolTheme.tsx
@@ -1,6 +1,15 @@
 "use client";
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { MANAGED, themeVars } from "@/components/theme/themeVars";
 import { getSchool, type School } from "@/data/schools";
 
 /**
@@ -27,51 +36,38 @@ export function useSchoolTheme() {
   return useContext(SchoolThemeContext);
 }
 
-/** Maps one brand colour onto the whole token set. */
-function themeVars(primary: string, accent?: string): Record<string, string> {
-  const mix = (pct: number, towards: string) => `color-mix(in oklab, ${primary} ${pct}%, ${towards})`;
-  return {
-    "--color-brand-700": mix(80, "black"),
-    "--color-brand-600": primary,
-    "--color-brand-500": mix(86, "white"),
-    "--color-brand-400": mix(64, "white"),
-
-    "--color-sky-500": mix(50, "white"),
-    "--color-sky-400": mix(36, "white"),
-    "--color-sky-300": mix(24, "white"),
-    "--color-sky-200": mix(15, "white"),
-    "--color-sky-100": mix(8, "white"),
-    "--color-sky-50": mix(4, "white"),
-
-    "--color-ink-950": mix(30, "black"),
-    "--color-ink-900": mix(38, "black"),
-    "--color-ink-800": mix(50, "black"),
-    "--color-ink-700": mix(62, "black"),
-    "--color-ink-600": mix(74, "black"),
-
-    "--color-paper": mix(3.5, "white"),
-    "--color-line": mix(14, "white"),
-    "--color-line-soft": mix(7, "white"),
-    "--color-body": `color-mix(in oklab, ${primary} 42%, #33445a)`,
-    "--color-body-soft": `color-mix(in oklab, ${primary} 26%, #6f8296)`,
-
-    "--color-accent": accent ?? mix(45, "white"),
-  };
-}
-
-const MANAGED = Object.keys(themeVars("#000"));
-
 export function SchoolThemeProvider({ children }: { children: React.ReactNode }) {
   const [schoolId, setSchoolId] = useState<string | null>(null);
   const school = useMemo(() => (schoolId ? getSchool(schoolId) ?? null : null), [schoolId]);
+
+  /*
+   * Whether this run is the mount rather than a real switch.
+   *
+   * On a page the server themed (see themeCss, and the <style> the onboarding
+   * frame renders), the colours on screen at mount are already the right ones
+   * and this effect changes none of them. Adding `theme-shift` anyway opened a
+   * 620ms window where every element on the page transitions its colours, for a
+   * switch that is not happening -- which is what turned the old default-blue
+   * flash into a visible fade rather than something you could miss.
+   *
+   * A ref, not state: flipping it must not re-render, and it must survive the
+   * effect it guards.
+   */
+  const mounted = useRef(false);
 
   useEffect(() => {
     const root = document.documentElement;
 
     // Colours cross-fade only while a switch is happening. A permanent global
     // colour transition would also animate every hover state on the page.
-    root.classList.add("theme-shift");
-    const done = window.setTimeout(() => root.classList.remove("theme-shift"), 620);
+    const switching = mounted.current;
+    mounted.current = true;
+
+    let done: number | undefined;
+    if (switching) {
+      root.classList.add("theme-shift");
+      done = window.setTimeout(() => root.classList.remove("theme-shift"), 620);
+    }
 
     if (school?.brand) {
       const vars = themeVars(school.brand.primary, school.brand.accent);
@@ -82,7 +78,9 @@ export function SchoolThemeProvider({ children }: { children: React.ReactNode })
       delete root.dataset.school;
     }
 
-    return () => window.clearTimeout(done);
+    return () => {
+      if (done !== undefined) window.clearTimeout(done);
+    };
   }, [school]);
 
   const setSchool = useCallback((id: string | null) => setSchoolId(id), []);

--- a/src/frontend/components/theme/themeVars.ts
+++ b/src/frontend/components/theme/themeVars.ts
@@ -1,0 +1,84 @@
+import type { School } from "@/data/schools";
+
+/**
+ * The colour maths, in a module with no "use client" on it.
+ *
+ * It lives apart from SchoolTheme.tsx because two very different things need
+ * it and only one of them runs in a browser:
+ *
+ *   SchoolThemeProvider   sets these as inline properties on <html> in an
+ *                         effect, which is what repaints the site when a
+ *                         student picks a school without reloading.
+ *   themeCss below        renders the same values into a <style> the server
+ *                         sends, so a page that already knows the school is
+ *                         drawn in its colours on the very first paint.
+ *
+ * Sharing one function is the point. Two copies would drift, and the symptom
+ * would be a school whose green is subtly wrong for one frame after every hard
+ * load, which nobody would ever catch by reading either file on its own.
+ *
+ * A server component cannot call a function it imports from a "use client"
+ * module -- it gets a client reference, not the function -- so keeping this
+ * file free of that directive is what makes the sharing possible at all.
+ */
+
+/** Maps one brand colour onto the whole token set. */
+export function themeVars(primary: string, accent?: string): Record<string, string> {
+  const mix = (pct: number, towards: string) => `color-mix(in oklab, ${primary} ${pct}%, ${towards})`;
+  return {
+    "--color-brand-700": mix(80, "black"),
+    "--color-brand-600": primary,
+    "--color-brand-500": mix(86, "white"),
+    "--color-brand-400": mix(64, "white"),
+
+    "--color-sky-500": mix(50, "white"),
+    "--color-sky-400": mix(36, "white"),
+    "--color-sky-300": mix(24, "white"),
+    "--color-sky-200": mix(15, "white"),
+    "--color-sky-100": mix(8, "white"),
+    "--color-sky-50": mix(4, "white"),
+
+    "--color-ink-950": mix(30, "black"),
+    "--color-ink-900": mix(38, "black"),
+    "--color-ink-800": mix(50, "black"),
+    "--color-ink-700": mix(62, "black"),
+    "--color-ink-600": mix(74, "black"),
+
+    "--color-paper": mix(3.5, "white"),
+    "--color-line": mix(14, "white"),
+    "--color-line-soft": mix(7, "white"),
+    "--color-body": `color-mix(in oklab, ${primary} 42%, #33445a)`,
+    "--color-body-soft": `color-mix(in oklab, ${primary} 26%, #6f8296)`,
+
+    "--color-accent": accent ?? mix(45, "white"),
+  };
+}
+
+/** Every token a school theme owns. The provider clears exactly these when a
+ *  school is dropped, so nothing from the last one survives. */
+export const MANAGED = Object.keys(themeVars("#000"));
+
+/**
+ * The same tokens as a stylesheet, for a server render.
+ *
+ * `:root:root` rather than `:root` is deliberate. The default palette is a
+ * plain `:root` block inside Tailwind's stylesheet, which is a <link> in the
+ * head, and equal specificity would leave this depending on document order --
+ * fine today, and quietly broken the day React decides to hoist this <style>
+ * above that link. Repeating the selector costs nothing and settles it.
+ *
+ * Every value here comes from data/schools.ts, which is ours and committed, so
+ * there is no untrusted text going into a stylesheet. Keep it that way: a
+ * school colour that ever came from a URL or a form would need escaping before
+ * it reached this string.
+ */
+export function themeCss(school: School): string | null {
+  if (!school.brand) return null;
+
+  const vars = themeVars(school.brand.primary, school.brand.accent);
+  const body = Object.entries(vars)
+    .map(([key, value]) => `${key}:${value}`)
+    .join(";");
+
+  return `:root:root{${body}}`;
+}

--- a/src/frontend/lib/firebaseClient.ts
+++ b/src/frontend/lib/firebaseClient.ts
@@ -1,14 +1,10 @@
 "use client";
 
-import { getApp, getApps, initializeApp, type FirebaseApp } from "firebase/app";
-import {
-  RecaptchaVerifier,
-  getAuth,
-  inMemoryPersistence,
-  signInWithPhoneNumber,
-  type Auth,
-  type ConfirmationResult,
-} from "firebase/auth";
+// Types only, so none of this survives compilation. Every value from the SDK is
+// pulled in by the dynamic import in `sdk()` below -- see the note there for
+// why that is worth the asynchrony it costs.
+import type { FirebaseApp } from "firebase/app";
+import type { Auth, ConfirmationResult, RecaptchaVerifier } from "firebase/auth";
 
 /**
  * Firebase Auth in the browser. Identity only, and identity is a phone number.
@@ -39,21 +35,57 @@ const firebaseConfig = {
   appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
 };
 
-function app(): FirebaseApp {
+/**
+ * The SDK, fetched on demand rather than bundled into the page.
+ *
+ * firebase/app plus firebase/auth is around 40 kB gzipped, and it used to be a
+ * static import, which put all of it in the chunk the browser has to download
+ * and parse before /onboarding can hydrate. None of it is needed to draw the
+ * first screen or to type a phone number into it -- the earliest it does any
+ * work is the press of "Text me a code" -- so paying for it up front bought
+ * nothing and made the first arrival on the page visibly slower.
+ *
+ * `warmPhoneAuth` below starts this fetch as soon as the number screen mounts,
+ * so by the time a student has typed ten digits it has almost always landed and
+ * the press is no slower than it was. The import cache makes every later call
+ * free, and a failed fetch simply retries on the next one.
+ */
+async function sdk() {
+  const [{ getApp, getApps, initializeApp }, auth] = await Promise.all([
+    import("firebase/app"),
+    import("firebase/auth"),
+  ]);
+  return { getApp, getApps, initializeApp, ...auth };
+}
+
+/**
+ * Pulls the SDK down ahead of the first press, and swallows failures.
+ *
+ * Called from an effect, so it must never reject: a rejected floating promise
+ * here would be an unhandled rejection over a fetch that is only ever an
+ * optimisation. Whatever went wrong will surface properly, with a message a
+ * student can act on, when `sendVerificationCode` retries the same import.
+ */
+export function warmPhoneAuth(): void {
+  void sdk().catch(() => {});
+}
+
+function app(mod: Awaited<ReturnType<typeof sdk>>): FirebaseApp {
   if (!firebaseConfig.apiKey || !firebaseConfig.authDomain || !firebaseConfig.appId) {
     throw new Error(
       "Firebase web config is missing. Set NEXT_PUBLIC_FIREBASE_API_KEY, " +
         "NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN and NEXT_PUBLIC_FIREBASE_APP_ID.",
     );
   }
-  return getApps().length ? getApp() : initializeApp(firebaseConfig);
+  return mod.getApps().length ? mod.getApp() : mod.initializeApp(firebaseConfig);
 }
 
 let cached: Auth | undefined;
 
-function clientAuth(): Auth {
+async function clientAuth(): Promise<Auth> {
+  const mod = await sdk();
   if (!cached) {
-    cached = getAuth(app());
+    cached = mod.getAuth(app(mod));
     // Google's own screens and the SMS itself, in the student's language.
     cached.useDeviceLanguage();
   }
@@ -74,9 +106,12 @@ function clientAuth(): Auth {
  */
 let verifier: RecaptchaVerifier | undefined;
 
-function appVerifier(containerId: string): RecaptchaVerifier {
+async function appVerifier(containerId: string): Promise<RecaptchaVerifier> {
   if (!verifier) {
-    verifier = new RecaptchaVerifier(clientAuth(), containerId, { size: "invisible" });
+    const mod = await sdk();
+    verifier = new mod.RecaptchaVerifier(await clientAuth(), containerId, {
+      size: "invisible",
+    });
   }
   return verifier;
 }
@@ -116,7 +151,12 @@ export async function sendVerificationCode(
   if (digits.length !== 10) throw new Error("invalid-phone");
 
   try {
-    return await signInWithPhoneNumber(clientAuth(), `+1${digits}`, appVerifier(containerId));
+    const mod = await sdk();
+    return await mod.signInWithPhoneNumber(
+      await clientAuth(),
+      `+1${digits}`,
+      await appVerifier(containerId),
+    );
   } catch (err) {
     resetVerifier();
     throw err;
@@ -137,7 +177,8 @@ export async function confirmCode(
   pending: PendingVerification,
   code: string,
 ): Promise<string> {
-  await clientAuth().setPersistence(inMemoryPersistence);
+  const mod = await sdk();
+  await (await clientAuth()).setPersistence(mod.inMemoryPersistence);
   const credential = await pending.confirm(code.replace(/\D/g, ""));
   // Once the code is spent the widget is too. A student who signs out and back
   // in during the same page life needs a fresh one.
@@ -149,7 +190,10 @@ export async function confirmCode(
  *  DELETE /api/auth/session, which is the half that actually matters. */
 export async function signOutClient(): Promise<void> {
   resetVerifier();
-  await clientAuth().signOut();
+  // Nothing to sign out of if the SDK was never loaded, and loading 40 kB in
+  // order to sign out of nothing would be the wrong trade.
+  if (!cached) return;
+  await cached.signOut();
 }
 
 /**


### PR DESCRIPTION
Picking a school and pressing **i'm ready to start** paused before the setup card appeared — but only ever on the first press. Everything the second press reused, the first press had to fetch, with nothing on screen while it did.

## What it was paying for

`/onboarding` is `force-dynamic`, and Next prefetches a dynamic route only as far as its nearest loading boundary. There was no `loading.tsx`, so there was no boundary. Measured against a production build, the prefetch the hero's `<Link>` fires returned **186 bytes** and named **zero** chunks to preload — the router cached nothing and learned nothing.

So the click paid for all of it at once: a cold RSC round trip, plus **185 kB raw / ~57 kB gzipped** of JavaScript the browser had never seen. About 40 kB gzipped of that was the Firebase Auth SDK, statically imported by the wizard and therefore parsed before the page could hydrate, despite doing nothing until the student presses *Text me a code*.

On the server, `page.tsx` awaited `getSession()` and `getUserByAuthUid()` in its own body, above the `<Suspense>` boundary. A boundary with nothing suspending under it streams nothing, so the response could not start until Firebase Admin had verified the session cookie (a network call — `checkRevoked` is on) and Firestore had answered.

Locally none of this shows: the RSC render is ~4 ms and chunks come off localhost. It is real on a phone on campus wifi.

## Changes

| | |
| --- | --- |
| `app/onboarding/loading.tsx` | The load-bearing one. Gives the prefetcher a boundary to stop at, so the route's JS is fetched while the student is still choosing a school. |
| `app/onboarding/page.tsx` | Synchronous again; an async child does the two reads below the boundary, so the card flushes first. |
| `lib/firebaseClient.ts` | `firebase/app` + `firebase/auth` move to a dynamic `import()`, warmed from an effect after mount instead of blocking hydration. |
| `components/onboarding/shell.tsx` | `Shell`, `Progress` and the page frame extracted so `loading.tsx` renders the exact same card server-side. |

## Measured, production build

| | before | after |
| --- | --- | --- |
| Prefetch payload | 186 B, 0 chunks | 10.3 kB, 5 chunks |
| New JS on the `/` → `/onboarding` hop | 185 kB raw / 57 kB gz | 69 kB raw / 21 kB gz |
| `/onboarding` route JS | 56.5 kB | 16.6 kB |
| `/onboarding` first load JS | 167 kB | 132 kB |

## Verified

- `?school=tmu` still renders *What is your number?* and the school name in the server HTML; no param still renders the picker.
- The skeleton's header, back arrow and progress bar are the real components, not placeholders — only the body is greyed, so nothing moves when the wizard lands.
- `npm run typecheck` clean. (`npm run lint` prompts to configure ESLint interactively — not set up in this repo, so not run.)

## One thing checked and deliberately not changed

`useSearchParams()` under Suspense is documented to fall back to client rendering on a *statically* rendered route. It does not apply here — `force-dynamic` takes the route out of that case, confirmed against a production build. The hook stays.

## The rule this leaves behind

`components/onboarding/shell.tsx` must not gain a `"use client"`. A hook or browser API anywhere in it drags the whole wizard bundle into the loading boundary and silently undoes this, with nothing in the build output to flag it. Noted in `docs/design/16-onboarding-entry-cost.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)