### PR TITLE
Key onboarding by the Firebase uid, and let the reCAPTCHA render

### DIFF
--- a/docs/design/15-firebase-auth.md
+++ b/docs/design/15-firebase-auth.md
@@ -42,37 +42,68 @@ The upside of the split, which was not the reason for it: **the grant is
 one-time.** A returning student signs in with a code and, if `google_connected_at`
 is already set, never sees the consent screen again.
 
-## The two ids, and the seam between them
+## One id, and the two that came before it
 
-This is the part that most needs to be understood before changing anything here.
+**Everything is keyed by the Firebase `uid`.** The Google `sub` is a field on
+the user document, `google_sub`, and nothing else.
 
 | | Firebase `uid` | Google `sub` |
 | --- | --- | --- |
-| Comes from | phone sign-in | the connector's code exchange |
+| Comes from | phone sign-in | the code exchange |
 | Exists from | step 0 | step 1 |
-| Keys | nothing | `users/`, `credentials/`, every connector call |
+| Keys | `users/`, `credentials/` | nothing |
+| Used for | everything | addressing the connector's endpoints |
 
-Firestore is keyed by the Google `sub`, and so is every endpoint the ADK agent
-calls, against a contract
-[frozen for the Aug 22 build](../../src/backend/connectors-api/API_CONTRACT.md).
-None of that changed. What changed is that the session no longer knows that id.
+This is the reverse of how it was first built, and the reversal is worth
+recording because the original reasoning was sound and still lost.
 
-So:
+### Why it was keyed by `sub`
 
-- **Nothing is written during the first half of onboarding.** A verified phone
-  with no `sub` has no document to be written to, and inventing a key to hold a
-  half record would mean migrating it later.
-- **`recordGoogleConnection` is where the user document is born.** It is the
-  first moment a `sub` exists, and it writes `auth_uid` and `phone_number` from
-  the session in the same breath. That one write is the entire bridge between
-  the two identities.
-- **`getUserByAuthUid` is how anything gets back across.** Single-field
-  equality, so Firestore's automatic index covers it and nothing has to be
-  deployed alongside.
+[API_CONTRACT.md](../../src/backend/connectors-api/API_CONTRACT.md) freezes
+`{user_id}` as the `sub` returned from `/auth/callback`, and every connector
+endpoint is `/users/{user_id}/...`. Keying Firestore the same way meant one id
+end to end and nothing to join.
 
-A signed-in student with no user document is therefore the *normal* state in the
-middle of onboarding, not an error, and code that reads the document has to say
-so rather than treating absence as a fault.
+### Why that was undone
+
+The `sub` does not exist until the access grant completes, and three things
+followed from that, all of them costs:
+
+- **Nothing could be written during the first half of onboarding.** A verified
+  phone had no key to be written under, so a student who stopped between the SMS
+  and the grant left no trace at all. That was carried in this document as a
+  known gap for as long as the `sub` was the key.
+- **Every read needed a translation.** The session carries a `uid` and never a
+  `sub`, so `getUserByAuthUid` ran an indexed equality query whose entire job
+  was converting one into the other.
+- **The key could change.** Reconnecting a different Google account yields a
+  different `sub`, and therefore a different document id, orphaning the old one.
+  A `uid` is stable for the life of the account.
+
+The argument that held it in place also expired: issue #12 rewrites the
+connector's storage path outright, and moves the code exchange to this app, so
+the `sub` is no longer something the connector hands us in the first place. The
+contract was going to be edited regardless, and the `users` collection was still
+empty, so the migration cost was zero. There would not have been a cheaper
+moment.
+
+### What that changes in the code
+
+- **`ensureUser` creates the document when the number is verified**, from
+  `POST /api/auth/session`. Insert-only, so signing in again never resets a
+  returning student's school, consent, or grant.
+- **`recordGoogleConnection` no longer creates anything.** It adds the school
+  address and `google_sub` to a document that is already there.
+- **`getUser(uid)` is a direct document read.** `getUserByAuthUid` and its query
+  are gone, and so is the `auth_uid` field.
+- **A signed-in student always has a document.** Absence is no longer the normal
+  mid-onboarding state; what distinguishes "verified but not granted" is
+  `google_connected_at` being unset, which is a fact about the student rather
+  than an accident of which id existed yet.
+
+> [!IMPORTANT]
+> Anything calling the connector must send `google_sub`, **not** the document
+> id. The endpoints are still addressed by the `sub`.
 
 ### An earlier version of this document was Google-keyed
 
@@ -201,28 +232,67 @@ password, so it now sits on the step it is accurate on and argues for.
 ## Setup this depends on
 
 None of it is code, and all of it is required. Firebase Auth had never been
-provisioned on `classisstant` when this was built: the Identity Toolkit admin
-API returned `CONFIGURATION_NOT_FOUND`.
+provisioned on `classisstant` when this was written: the Identity Toolkit admin
+API returned `CONFIGURATION_NOT_FOUND`. **It has since been done**, and what
+follows is the record of what it took, because none of it is discoverable from
+the failure messages.
 
-1. **Enable Firebase Authentication** on `classisstant`, and enable **Phone** as
-   a sign-in provider.
-2. **Authorised domains** must include `localhost` and
+1. **Firebase Authentication is initialised** and **Phone** is enabled.
+   Provisioned through `identityPlatform:initializeAuth` on the Identity Toolkit
+   v2 admin API rather than the console; the console's "Get started" does the
+   same thing.
+2. **Authorised domains** are `localhost`, `127.0.0.1`,
+   `classisstant.firebaseapp.com`, `classisstant.web.app`, and
    `classistant--classisstant.us-central1.hosted.app`. Missing here surfaces as
    `auth/unauthorized-domain`.
-3. **IAM on the App Hosting runtime service account.** Minting a session cookie
-   signs a JWT *as* that account, so it needs
-   `roles/iam.serviceAccountTokenCreator` on itself, plus
-   `roles/firebaseauth.admin`. Without it every sign-in fails at the last step,
-   after the student has already received the SMS, with a permission error from
-   the IAM signBlob API.
-4. **Phone auth costs money and has a quota.** SMS is billed per message and the
-   project needs Blaze. Add test numbers in the console during development:
-   Firebase lets a fixed number and code through without sending anything, and
-   `123456` is the convention the scene is drawn around.
+3. **The SMS region allowlist starts empty, and empty means nothing is
+   allowed.** A fresh config carries `smsRegionConfig.allowlistOnly: {}`, which
+   silently refuses every send. It is set to `["CA"]`. This is invisible in the
+   console until looked for and is the single least obvious item on this list.
+4. **Blaze is required and is enabled.** SMS is billed per message.
+5. **IAM needs nothing extra.** An earlier version of this document claimed the
+   runtime service account required `roles/iam.serviceAccountTokenCreator` on
+   itself plus `roles/firebaseauth.admin`. It does not:
+   `createSessionCookie` is a plain Identity Toolkit call, not a local JWT
+   signing operation, and `firebase-app-hosting-compute@` already holds
+   `firebaseauth.users.createSession` through
+   `roles/firebase.sdkAdminServiceAgent`. The `serviceAccountTokenCreator`
+   requirement is real for `createCustomToken`, which this app does not call.
+6. **Local development needs Application Default Credentials.**
+   `gcloud auth application-default login`, then
+   `gcloud auth application-default set-quota-project classisstant`. This is
+   separate from `gcloud auth login`; having one does not give the other, and
+   `lib/firebaseAdmin.ts` reads only the second. Without it every server-side
+   step after the code is accepted fails.
 
-`lib/firebaseClient.ts` maps `auth/configuration-not-found` and
-`auth/operation-not-allowed` to their own messages so a half-configured project
-fails loudly during setup rather than looking like an ordinary sign-in failure.
+> [!WARNING]
+> **Test numbers must be removed before launch.** A number in
+> `signIn.phoneNumber.testPhoneNumbers` signs in with a fixed code and **no
+> SMS** — an auth bypass on a real number if one is left there. `+1 647 555-0134`
+> / `123456` is the fictional one the scene is drawn around and is safe to keep
+> in development. Clear the map with:
+>
+> ```
+> PATCH .../v2/projects/classisstant/config?updateMask=signIn.phoneNumber
+> {"signIn":{"phoneNumber":{"enabled":true,"testPhoneNumbers":{}}}}
+> ```
+
+`lib/firebaseClient.ts` maps `auth/configuration-not-found`,
+`auth/operation-not-allowed`, `auth/invalid-app-credential` and
+`auth/billing-not-enabled` to their own messages, and logs the raw error for
+anything unmapped, so a half-configured project fails loudly during setup rather
+than looking like an ordinary sign-in failure.
+
+### Anti-abuse throttling looks like a configuration error
+
+A run of failed sends trips Google's per-number abuse protection, after which
+`sendVerificationCode` returns `TOO_MANY_ATTEMPTS_TRY_LATER` and the browser
+gets `auth/invalid-app-credential` — *even when the reCAPTCHA challenge was
+solved correctly*. It reads exactly like a broken project and is not one.
+
+It is time-based, there is no API to clear it, and **every retry re-arms it**.
+The way through is a different number, or waiting. Worth knowing before spending
+an afternoon on the config, which is how this note came to exist.
 
 ### reCAPTCHA is not optional
 
@@ -230,7 +300,7 @@ Firebase refuses `signInWithPhoneNumber` without an `AppVerifier`. It is what
 stands between the form and someone spending the SMS budget in a loop. Invisible
 size, so ordinary traffic never sees a challenge.
 
-Two things about it that cost time:
+Three things about it that cost time:
 
 - **The verifier is a module-level singleton.** Constructing a second one against
   the same container throws, and a re-render must not be able to cause that.
@@ -238,12 +308,40 @@ Two things about it that cost time:
   and reusing it produces `auth/captcha-check-failed` on every retry after the
   first, which looks exactly like the student's number being at fault.
   `resetVerifier()` exists for that and is called on every failure path.
+- **The container must be laid out, and must not be sized to nothing.** This one
+  cost the most, so it is written out in full below.
 
 The container is rendered for the whole wizard rather than inside step 0, and
 outside the `<form>`. Inside step 0 it would be a new DOM node whenever a student
 navigated back to it while the verifier still held the old one; inside the form
 it would put an injected iframe and hidden input into a form whose action writes
 a student's account.
+
+#### The container is an empty, unstyled `<div>`, and both halves of that matter
+
+```jsx
+<div id={RECAPTCHA_ID} />
+```
+
+It shipped as `className="hidden"`. Tailwind's `hidden` is `display: none`, and
+grecaptcha cannot mint a token from a container it cannot lay out — invisible
+size still has to be able to raise a challenge over the page for traffic Google
+does not trust. Every send failed with `auth/invalid-app-credential`, which
+names the *app credential* and not the container, and reads as a project
+misconfiguration.
+
+The obvious repair, `h-0 w-0 overflow-hidden`, breaks it a second way:
+grecaptcha renders its anchor iframe **inside** this element, and clipping that
+to zero makes it read positions off a node with no box. That throws
+`Cannot read properties of null (reading 'style')` from inside
+`recaptcha__en.js`.
+
+At `size: "invisible"` an empty div is the whole answer. It collapses to nothing
+on its own, and the floating badge is `position: fixed` and never lived in the
+container anyway.
+
+The general rule, which generalises past this file: **`hidden` is wrong for any
+third-party widget that has to render.**
 
 ### The config is hand-synced, again
 
@@ -260,13 +358,18 @@ credential; every Firebase web app ships it to every browser. Re-read them with
 
 ## Known gaps
 
-- **Sign-in is not end-to-end tested.** It cannot be until step 1 above is done.
-  Everything below the SMS is: validation, token rejection, the admin SDK, the
-  callback guards, and the build all verified locally.
-- **Abandoning between the code and the grant loses the school and address.**
-  Nothing is written until the grant completes, so a reload in that window drops
-  back to whatever `?school=` carries. The fix, if it turns out to matter, is a
-  document keyed by `auth_uid` for in-progress onboarding.
+- **Sign-in is not end-to-end tested through a real SMS.** The project side is
+  verified: `sendVerificationCode` and `signInWithPhoneNumber` were both driven
+  directly against Identity Toolkit and returned a real `localId`, so phone auth
+  works. What has not been observed is a real code arriving on a real handset and
+  being typed into the wizard, because the number used for development is
+  throttled (see above) and the alternative was an allowlisted test number, which
+  never sends anything.
+- ~~**Abandoning between the code and the grant loses the school and address.**~~
+  **Closed** by keying on the Firebase `uid`. The document now exists from the
+  moment the number is verified, so there is somewhere to write in-progress
+  onboarding to. The fix this gap proposed — "a document keyed by `auth_uid`" —
+  is what rekeying made unnecessary rather than what it took.
 - **`serviceEmail` is no longer collected.** The optional "different Google
   account for Drive and Calendar" field was on the old details screen, which the
   access switches replaced. The field is still on `UserProfile` and is written as

--- a/src/frontend/app/api/auth/session/route.ts
+++ b/src/frontend/app/api/auth/session/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 
 import { SignInRejected, clearSession, createSession } from "@/lib/authSession";
-import { getUserByAuthUid } from "@/lib/users";
+import { ensureUser, getUser } from "@/lib/users";
 
 /**
  * Turns a Firebase ID token into a session cookie, and back again.
@@ -49,10 +49,16 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "We could not sign you in." }, { status: 500 });
   }
 
+  // The document is born here, at the first verified number, and this is the
+  // whole point of keying by uid: before the rekey there was no id to write
+  // under until the Google grant completed, so a student who stopped after the
+  // SMS left nothing behind. Insert-only, so a returning student keeps their
+  // school, consent, and grant.
+  await ensureUser({ uid: session.uid, phoneNumber: session.phone });
+
   // A returning student may already have finished the grant on a previous
-  // visit, in which case the consent screen is not shown again. Absent is the
-  // normal case: the document is not created until the grant completes.
-  const record = await getUserByAuthUid(session.uid);
+  // visit, in which case the consent screen is not shown again.
+  const record = await getUser(session.uid);
 
   return NextResponse.json({
     phone: session.phone,

--- a/src/frontend/app/onboarding/actions.ts
+++ b/src/frontend/app/onboarding/actions.ts
@@ -10,7 +10,7 @@ import { FieldValue } from "@/lib/firebaseAdmin";
 import { buildAuthUrl, randomState } from "@/lib/googleOAuth";
 import { setPendingOAuth } from "@/lib/onboardingSession";
 import {
-  getUserByAuthUid,
+  getUser,
   markOnboardingComplete,
   savePortalCredentials,
   upsertUser,
@@ -133,8 +133,8 @@ export async function connectGoogle(
 /**
  * Final submit. Writes both onboarding collections.
  *
- *   users/{sub}        profile + consent evidence
- *   credentials/{sub}  portal username + a Secret Manager pointer
+ *   users/{uid}        profile + consent evidence
+ *   credentials/{uid}  portal username + a Secret Manager pointer
  *
  * Identity comes from the session cookie and the user document, never from the
  * form. The form is client-supplied, and the whole point of the SMS round trip
@@ -159,12 +159,13 @@ export async function completeOnboarding(
   }
 
   /*
-   * Everything identifying comes off the document, which only exists because
-   * the access grant completed. A student who verified a number but never got
-   * through Google has nothing to finish with, and that is the honest error
-   * rather than writing a half record under an id we would have to invent.
+   * Everything identifying comes off the document. It exists from the moment
+   * the number was verified, but the school address on it only arrives with the
+   * grant, so a student who never got through Google still has nothing to
+   * finish with -- `googleConnected` is the check that says so, not the
+   * presence of the document.
    */
-  const profile = await getUserByAuthUid(session.uid);
+  const profile = await getUser(session.uid);
   if (!profile || !profile.googleConnected || !profile.email) {
     return {
       ok: false,

--- a/src/frontend/app/onboarding/callback/route.ts
+++ b/src/frontend/app/onboarding/callback/route.ts
@@ -105,9 +105,12 @@ export async function GET(request: NextRequest) {
     return back(request, { error: "unreachable" }, school.id);
   }
 
-  const userId = payload.user_id;
+  // The connector returns the Google `sub`. It is no longer our document key --
+  // see the header of lib/users.ts -- but it is still how the connector's own
+  // `/users/{user_id}/...` endpoints are addressed, so it is stored.
+  const googleSub = payload.user_id;
   const email = payload.email?.toLowerCase();
-  if (!userId || !email) return back(request, { error: "exchange" }, school.id);
+  if (!googleSub || !email) return back(request, { error: "exchange" }, school.id);
 
   /*
    * School eligibility, and this is the check that actually enforces it.
@@ -134,15 +137,15 @@ export async function GET(request: NextRequest) {
     return back(request, { error: "mismatch" }, school.id);
   }
 
-  // The write that binds the phone identity to the Google one. Everything
-  // downstream is keyed by `sub`; the session's uid and number are what make it
-  // possible to get back here from a support or deletion request.
+  // Adds what the grant proved to a document that already exists. It was
+  // created when the number was verified, so this no longer has to carry the
+  // phone number across to bind two identities together -- there is only one
+  // identity now, and the `sub` is one of its fields.
   await recordGoogleConnection({
-    userId,
+    uid: session.uid,
+    googleSub,
     email,
     schoolId: school.id,
-    authUid: session.uid,
-    phoneNumber: session.phone,
   });
 
   return back(request, { connected: "1" }, school.id);

--- a/src/frontend/app/onboarding/page.tsx
+++ b/src/frontend/app/onboarding/page.tsx
@@ -4,7 +4,7 @@ import { OnboardingWizard } from "@/components/onboarding/OnboardingWizard";
 import { OnboardingFrame, WizardSkeleton } from "@/components/onboarding/shell";
 import { getSchool } from "@/data/schools";
 import { getSession } from "@/lib/authSession";
-import { getUserByAuthUid } from "@/lib/users";
+import { getUser } from "@/lib/users";
 
 export const metadata: Metadata = {
   title: "Get set up",
@@ -19,7 +19,7 @@ export const dynamic = "force-dynamic";
 /**
  * The page itself is synchronous now, and that is the point.
  *
- * It used to await getSession() and getUserByAuthUid() in this function body,
+ * It used to await getSession() and the user read in this function body,
  * above the Suspense boundary. A boundary with nothing suspending under it
  * streams nothing, so the browser held on the previous page until Firebase
  * Admin had verified the session cookie -- a network call, because checkRevoked
@@ -64,10 +64,10 @@ async function SignedInWizard() {
   //
   // Three states, not two, and the wizard opens on a different step for each:
   // nobody here, a verified number with no access grant, or both. The document
-  // read is what distinguishes the last two, and it only exists once the grant
-  // has happened.
+  // exists from the moment the number was verified, so what distinguishes the
+  // last two is `googleConnected` on it, not whether it is there at all.
   const session = await getSession();
-  const record = session ? await getUserByAuthUid(session.uid) : null;
+  const record = session ? await getUser(session.uid) : null;
 
   const account = session
     ? {

--- a/src/frontend/components/onboarding/OnboardingWizard.tsx
+++ b/src/frontend/components/onboarding/OnboardingWizard.tsx
@@ -971,8 +971,25 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
 
         Outside the <form> on purpose: it injects an iframe and a hidden input,
         and neither belongs in a form whose action writes a student's account.
+
+        Deliberately unstyled, and that is load-bearing in both directions.
+
+        `hidden` (`display: none`) breaks it: grecaptcha cannot mint a token
+        from a container it cannot lay out, and it fails as
+        `auth/invalid-app-credential`, which reads exactly like a project
+        misconfiguration and is not one.
+
+        Sizing it to nothing (`h-0 w-0 overflow-hidden`) breaks it differently:
+        grecaptcha renders its anchor iframe INSIDE this element, and clipping
+        that to zero makes it read positions off a node with no box, which
+        throws "Cannot read properties of null (reading 'style')" from inside
+        recaptcha__en.js.
+
+        At `size: "invisible"` an empty div is already the whole answer. It
+        collapses to nothing on its own, and the floating badge is
+        `position: fixed` and never lived in here anyway.
       */}
-      <div id={RECAPTCHA_ID} className="hidden" />
+      <div id={RECAPTCHA_ID} />
     </Shell>
   );
 }

--- a/src/frontend/lib/authSession.ts
+++ b/src/frontend/lib/authSession.ts
@@ -44,12 +44,12 @@ const COOKIE_OPTIONS = {
 
 export type AuthSession = {
   /**
-   * The Firebase uid. This is who is signed in.
+   * The Firebase uid. This is who is signed in, and it is also the id every
+   * Firestore document is keyed by, so it is the only id the app has.
    *
-   * It is NOT the id the Firestore documents are keyed by. Those are keyed by
-   * the Google `sub`, which does not exist until the student completes the
-   * access grant, so a signed-in student may legitimately have no document yet.
-   * `getUserByAuthUid` is the way across once they do.
+   * It used to be neither: documents were keyed by the Google `sub` and this
+   * had to be translated through an indexed query on every read. See the header
+   * of lib/users.ts for why that was undone.
    */
   uid: string;
   /** E.164, verified by Google via the SMS. The reason to trust it is that a

--- a/src/frontend/lib/firebaseClient.ts
+++ b/src/frontend/lib/firebaseClient.ts
@@ -203,8 +203,38 @@ export async function signOutClient(): Promise<void> {
  * is wrong for a wrong code and right for a network blip, and the difference is
  * the whole value of this function.
  */
+/**
+ * The codes that mean the student mistyped. Everything else is ours, and gets
+ * logged. Kept module level so the set is not rebuilt on every failure.
+ */
+const STUDENT_ERROR = new Set([
+  "auth/invalid-phone-number",
+  "invalid-phone",
+  "auth/invalid-verification-code",
+  "auth/code-expired",
+]);
+
 export function phoneErrorMessage(err: unknown): string {
   const code = typeof err === "object" && err && "code" in err ? String(err.code) : "";
+
+  if (!STUDENT_ERROR.has(code)) {
+    // `customData.serverResponse` is the half worth having: it carries Identity
+    // Toolkit's own message, which distinguishes causes the SDK flattens into a
+    // single code. `auth/invalid-app-credential` alone covers a rejected
+    // reCAPTCHA token, an unauthorised domain, and App Check enforcement.
+    const detail = err as {
+      message?: string;
+      customData?: { serverResponse?: unknown; appName?: string };
+    };
+    // `err` goes last and raw. `message` is non-enumerable on Error, so a
+    // plain object literal loses it in any structured view -- including
+    // Next's overlay, which renders the summary above as `{}` and reads like
+    // the SDK returned nothing. Expand the raw error in DevTools instead.
+    console.error("[phone auth]", code || "(no code)", {
+      message: detail?.message,
+      serverResponse: detail?.customData?.serverResponse,
+    }, err);
+  }
 
   switch (code) {
     case "auth/invalid-phone-number":
@@ -224,7 +254,7 @@ export function phoneErrorMessage(err: unknown): string {
     case "auth/network-request-failed":
       return "We could not reach Google. Check your connection and try again.";
 
-    // The next three are our own setup, not the student's, and none can be
+    // The next five are our own setup, not the student's, and none can be
     // fixed by trying again. Called out separately so a half-configured project
     // fails loudly during setup instead of looking like an ordinary failure.
     case "auth/unauthorized-domain":
@@ -233,8 +263,18 @@ export function phoneErrorMessage(err: unknown): string {
       return "Sign-in is not switched on yet. (Firebase Auth is not set up on the project.)";
     case "auth/operation-not-allowed":
       return "Phone sign-in is not enabled for this site yet.";
+    case "auth/invalid-app-credential":
+      // Identity Toolkit rejected the reCAPTCHA token rather than the number.
+      // Distinct from `captcha-check-failed`, which is a spent widget and does
+      // clear on a retry: this one is project config and never will.
+      return "The sign-in check was rejected. (reCAPTCHA is not accepted for this project yet.)";
+    case "auth/billing-not-enabled":
+      return "SMS sign-in needs billing switched on for this project.";
 
     default:
+      // Already logged above. Every code in this switch was learned by hitting
+      // it blind through this branch, so the logging is what keeps the next
+      // unmapped one to a glance rather than a bisect.
       return "We could not verify that number. Try again.";
   }
 }

--- a/src/frontend/lib/users.ts
+++ b/src/frontend/lib/users.ts
@@ -6,12 +6,27 @@ import { secretName, storePortalPassword } from "@/lib/portalCredentials";
 /**
  * The two onboarding collections.
  *
- *   users/{user_id}        profile + consent evidence
- *   credentials/{user_id}  school portal username + a pointer to the password
+ *   users/{uid}        profile + consent evidence
+ *   credentials/{uid}  school portal username + a pointer to the password
  *
- * Both are keyed by the Google `sub` returned from the connector's
- * /auth/callback, which is also what the ADK agent passes on every connector
- * call. One id end to end, so nothing has to join.
+ * `uid` is the **Firebase Auth uid**, minted by phone sign-in.
+ *
+ * It used to be the Google `sub`, mirroring
+ * src/backend/connectors-api/API_CONTRACT.md, which freezes `{user_id}` as the
+ * `sub` returned from the connector's /auth/callback. That cost more than it
+ * bought and issue #12 is rewriting the connector anyway:
+ *
+ *  - The `sub` does not exist until the access grant completes, so there was no
+ *    key to write under during the first half of onboarding, and a student who
+ *    abandoned between the SMS and the grant left nothing behind at all.
+ *  - The session carries a uid, never a `sub`, so every read needed an indexed
+ *    query purely to translate one into the other.
+ *  - Reconnecting a different Google account changes the `sub`, and with it the
+ *    document id. A uid is stable for the life of the account.
+ *
+ * The `sub` is still kept, as `google_sub`, because the connector's endpoints
+ * are addressed by it. It is a field now, not an identity. Anything calling
+ * `/users/{user_id}/...` must send `google_sub`, NOT the document id.
  *
  * There is no `password` field on `credentials`, deliberately. The password
  * lives in Secret Manager and the document holds only its resource name -- see
@@ -30,6 +45,7 @@ export type ConsentRecord = {
 };
 
 export type UserProfile = {
+  /** The Firebase Auth uid, which is also the document id. */
   id: string;
   email: string;
   name: string;
@@ -109,10 +125,13 @@ export async function upsertUser(profile: UserProfile): Promise<void> {
  * phone number. Everything else about a student is ours to store.
  */
 export type UserRecord = {
-  /** The document id, which is the Google `sub`. */
+  /** The document id, which is the Firebase Auth uid. */
   userId: string;
   schoolId: string | null;
   email: string | null;
+  /** The Google `sub`, once the grant has happened. This is the id the
+   *  connector's endpoints are addressed by, and the only thing it is for. */
+  googleSub: string | null;
   /** Whether the Gmail/Drive/Docs/Calendar grant has been completed. Distinct
    *  from being signed in: identity is a phone number and arrives first. */
   googleConnected: boolean;
@@ -125,76 +144,80 @@ function toRecord(snap: FirebaseFirestore.DocumentSnapshot): UserRecord {
     userId: snap.id,
     schoolId: typeof data.school_id === "string" ? data.school_id : null,
     email: typeof data.email === "string" ? data.email : null,
+    googleSub: typeof data.google_sub === "string" ? data.google_sub : null,
     googleConnected: Boolean(data.google_connected_at),
     onboardingComplete: data.onboarding_complete === true,
   };
 }
 
 /**
- * Finds a student from their Firebase uid.
+ * The signed-in student's document, or null if they have none yet.
  *
- * This query is the seam created by verifying a phone before connecting Google.
- * The session knows a Firebase uid; the documents are keyed by the Google `sub`,
- * which does not exist until the grant completes. So there is no direct read
- * available, and a signed-in student with no document at all is the normal
- * state for the first half of onboarding rather than an error.
- *
- * Single-field equality, so Firestore's automatic index covers it and no
- * composite index has to be deployed alongside this.
+ * A direct document read. This replaced `getUserByAuthUid`, which had to run an
+ * indexed equality query because the session's uid was not the document key.
+ * Now it is, so there is nothing to look up.
  */
-export async function getUserByAuthUid(authUid: string): Promise<UserRecord | null> {
-  const found = await firestore()
-    .collection("users")
-    .where("auth_uid", "==", authUid)
-    .limit(1)
-    .get();
-
-  const snap = found.docs[0];
-  return snap ? toRecord(snap) : null;
+export async function getUser(uid: string): Promise<UserRecord | null> {
+  const snap = await firestore().collection("users").doc(uid).get();
+  return snap.exists ? toRecord(snap) : null;
 }
 
 /**
- * Records the access grant. This is where the user document is born.
+ * Creates the user document the moment a number is verified.
  *
- * Called from the OAuth callback, which is the first moment a Google `sub`
- * exists at all: the student verified a phone before this, and a phone session
- * carries no `sub` to key a document by. So nothing is written during the first
- * half of onboarding, and this one write binds the two identities together.
+ * This is the write that keying by uid makes possible at all. Under the old
+ * `sub` key there was nothing to write under until the access grant completed,
+ * so a student who left between the SMS and the grant left no trace, and
+ * docs/design/15 had to carry that as a known gap.
  *
- * Creating it here also means a student who abandons the rest of the wizard
- * still has a row. Their refresh token is already in Secret Manager by this
- * point, and a token with no user record is an orphan nobody can find to delete.
- *
- * `phone_number` is carried in from the session rather than collected again. It
- * was verified by an SMS round trip, which is a stronger claim than any field on
- * a form, and re-asking would invite a student to type a different number.
+ * Everything here is insert-only. A returning student re-verifying their number
+ * must not have their school, consent, or grant reset by signing in again.
  */
-export async function recordGoogleConnection(args: {
-  userId: string;
-  email: string;
-  schoolId: string;
-  authUid: string;
+export async function ensureUser(args: {
+  uid: string;
   phoneNumber: string;
 }): Promise<void> {
   await setStamped(
     "users",
-    args.userId,
+    args.uid,
+    { id: args.uid, phone_number: args.phoneNumber },
+    // Written explicitly rather than left absent so
+    // `where("onboarding_complete", "==", false)` can actually find them --
+    // Firestore equality never matches a missing field.
+    { onboarding_complete: false },
+  );
+}
+
+/**
+ * Records the access grant against an already existing user document.
+ *
+ * Before the rekey this function created the document, because the Google `sub`
+ * it was keyed by did not exist any earlier. Now the document is already there
+ * from `ensureUser`, and this only adds what the grant proved: the school
+ * address, and the `sub` the connector addresses its endpoints by.
+ *
+ * `phone_number` is not rewritten here. It was verified by an SMS round trip
+ * and stored at sign-in, and re-asserting it from the session would only invite
+ * the two to drift.
+ */
+export async function recordGoogleConnection(args: {
+  uid: string;
+  googleSub: string;
+  email: string;
+  schoolId: string;
+}): Promise<void> {
+  await setStamped(
+    "users",
+    args.uid,
     {
-      id: args.userId,
+      id: args.uid,
       email: args.email,
       school_id: args.schoolId,
-      // The bridge between the two ids. Everything downstream is keyed by the
-      // Google `sub`, and this is the only way back to the Firebase Auth record
-      // that holds the phone -- which is what a support request or a deletion
-      // request will arrive holding.
-      auth_uid: args.authUid,
-      phone_number: args.phoneNumber,
+      // A field, not an identity. The connector's `/users/{user_id}/...`
+      // endpoints are addressed by this, never by the document id.
+      google_sub: args.googleSub,
       google_connected_at: FieldValue.serverTimestamp(),
     },
-    // Insert-only: a student who reconnects Google after finishing should not
-    // be dragged back to incomplete. Written explicitly rather than left absent
-    // so `where("onboarding_complete", "==", false)` can actually find them --
-    // Firestore equality never matches a missing field.
     { onboarding_complete: false },
   );
 }


### PR DESCRIPTION
Two things, both blocking onboarding. Stacked on #13 so the diff stays readable; GitHub will retarget this to `main` once that merges.

## 1. Phone sign-in could never send a real SMS

The invisible reCAPTCHA container was `className="hidden"`. Tailwind's `hidden` is `display: none`, and grecaptcha cannot mint a token from a container it cannot lay out.

It surfaced as `auth/invalid-app-credential`, which names the *app credential* rather than the container, so it reads as a misconfigured project. It is not. Written up in `docs/design/15` at length because it cost most of a day.

Also fixed along the way, in the project rather than the code:

| | |
|---|---|
| Firebase Auth was never initialised on `classisstant` | Identity Toolkit returned `CONFIGURATION_NOT_FOUND` |
| SMS region allowlist was **empty**, which means nothing allowed | now `["CA"]` |
| `localhost` / `127.0.0.1` not authorised | added |
| Phone provider off | enabled |

Verified by driving `sendVerificationCode` and `signInWithPhoneNumber` straight against Identity Toolkit, which returns a real `localId`. Phone auth works.

## 2. `users` is keyed by the Firebase uid now, not the Google `sub`

Closes the `id` / `auth_uid` mismatch @obaodelana and I hit on #12.

The `sub` does not exist until the access grant completes, which cost three things:

- **Nothing could be written during the first half of onboarding.** A verified phone had no key to be written under. `docs/design/15` carried that as a known gap for exactly as long as the `sub` was the key. **This PR closes it.**
- **Every read needed a translation.** `getUserByAuthUid` ran an indexed query whose only job was uid → sub.
- **The key could change.** A different Google account means a different `sub`, so the document id moves and the old one orphans.

The `sub` is kept as `google_sub`, a field rather than an identity.

> [!IMPORTANT]
> @MatthewA15 — anything calling `/users/{user_id}/...` must send `google_sub`, **not** the document id. The connector's endpoints are still addressed by the `sub`; only our storage changed.

Timing: #12 rewrites the connector's storage path and moves the code exchange to this app, so the `sub` stops being something the connector hands us at all. The contract was going to be edited regardless, and the `users` collection was **empty**, so migration cost was zero.

## Checks

- `tsc --noEmit` clean
- `next build` passes
- Not yet exercised through a real handset: the dev number is throttled by Google's anti-abuse after the failures above, and the alternative is an allowlisted test number, which never sends anything

## ⚠️ Before launch

`+1 647 555-0134` / `123456` is currently allowlisted as a test number and signs in with **no SMS**. Removal steps are in `docs/design/15`.