### PR TITLE
Stop redirecting students to 0.0.0.0, and sign the connector call

### DIFF
--- a/docs/design/12-onboarding-persistence.md
+++ b/docs/design/12-onboarding-persistence.md
@@ -101,6 +101,56 @@ consent copy in `ScopeList` was saying "send email you have approved" and has
 been corrected. Consent copy that overstates the grant fails app review and is
 untrue to the student besides.
 
+### The connector is private, and the call to it must be signed
+
+`classistant-connectors` is **not** `--allow-unauthenticated`. It exchanges
+authorisation codes and writes refresh tokens to Secret Manager, so an open
+endpoint would be the wrong posture regardless of what the contract says.
+
+That means the server-to-server call from `/onboarding/callback` has to carry an
+OIDC identity token, and two things must line up or Cloud Run answers **403 with
+an HTML error page before the connector runs at all**:
+
+1. **The token.** `connectorIdToken()` asks the Cloud Run metadata server for
+   one, with `audience` set to the connector's own base URL — the audience is
+   checked, so the connector's URL is the only value that works. No library and
+   no key: the metadata server mints it for whatever service account the app
+   runs as. Off GCP it returns `null`, which keeps local development running.
+2. **The binding.** That service account needs `roles/run.invoker` **on the
+   connector**:
+
+   ```
+   gcloud run services add-iam-policy-binding classistant-connectors \
+     --region=us-central1 --project=classisstant \
+     --member="serviceAccount:firebase-app-hosting-compute@classisstant.iam.gserviceaccount.com" \
+     --role="roles/run.invoker"
+   ```
+
+> [!WARNING]
+> The frontend runs as **`firebase-app-hosting-compute@`**, the runtime compute
+> account. It is *not* `service-<number>@gcp-sa-firebaseapphosting.iam...`,
+> which is App Hosting's build-and-deploy **service agent** and never makes
+> runtime requests. Granting invoker to the agent looks right in the console and
+> changes nothing — that exact mistake produced two hours of `error=exchange` on
+> 2026-08-27. Check with
+> `gcloud run services describe classistant --format='value(spec.template.spec.serviceAccountName)'`.
+
+A `gcloud run deploy` without `--allow-unauthenticated` silently resets the
+policy, so if the grant starts failing after a connector redeploy, re-check the
+binding before anything else.
+
+### Redirects out of the callback must not be built from the request
+
+`back()` builds its URL from `appBaseUrl()` (`NEXT_PUBLIC_APP_URL`), never from
+`request.nextUrl.origin`. On Cloud Run the container is addressed as
+`0.0.0.0:8080` from inside, so a request-derived origin sends the student to
+`https://0.0.0.0:8080/onboarding` — unreachable, and Safari reports it as
+"restricted network port", which names neither the cause nor the fix. It is
+correct in local development, which is the only reason it survived review.
+
+This hit the **success** redirect too, not only the error paths: a student who
+granted access perfectly still dead-ended on a browser error page.
+
 ## The two collections
 
 ```

--- a/src/frontend/app/onboarding/callback/route.ts
+++ b/src/frontend/app/onboarding/callback/route.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 
 import { getSchool } from "@/data/schools";
 import { getSession } from "@/lib/authSession";
-import { connectorBaseUrl } from "@/lib/googleOAuth";
+import { appBaseUrl, connectorBaseUrl, connectorIdToken } from "@/lib/googleOAuth";
 import { takePendingOAuth } from "@/lib/onboardingSession";
 import { recordGoogleConnection } from "@/lib/users";
 
@@ -39,13 +39,17 @@ export const dynamic = "force-dynamic";
  * `pending` is gone by the time some of these fire, so it is optional and the
  * wizard still falls back to the school on the user document. One frame of the
  * wrong colour on a path that already failed is not worth more than this.
+ *
+ * The origin comes from `appBaseUrl()`, never from the request. It was
+ * `request.nextUrl.origin`, which is correct in development and wrong
+ * everywhere this actually runs: on Cloud Run the container is addressed as
+ * `0.0.0.0:8080` from inside, so every redirect out of this route -- the
+ * successful one included -- pointed at `https://0.0.0.0:8080/onboarding` and
+ * dead-ended the student on a browser error. Safari names it "restricted
+ * network port"; the cause is not the port.
  */
-function back(
-  request: NextRequest,
-  params: Record<string, string>,
-  schoolId?: string | null,
-) {
-  const url = new URL("/onboarding", request.nextUrl.origin);
+function back(params: Record<string, string>, schoolId?: string | null) {
+  const url = new URL("/onboarding", appBaseUrl());
   if (schoolId) url.searchParams.set("school", schoolId);
   for (const [k, v] of Object.entries(params)) url.searchParams.set(k, v);
   return NextResponse.redirect(url);
@@ -62,7 +66,6 @@ export async function GET(request: NextRequest) {
   if (oauthError) {
     // access_denied is a student clicking Cancel, not a fault.
     return back(
-      request,
       { error: oauthError === "access_denied" ? "cancelled" : "google" },
       pending?.schoolId,
     );
@@ -70,39 +73,52 @@ export async function GET(request: NextRequest) {
 
   const code = query.get("code");
   const state = query.get("state");
-  if (!code || !state) return back(request, { error: "incomplete" }, pending?.schoolId);
+  if (!code || !state) return back({ error: "incomplete" }, pending?.schoolId);
 
   // CSRF. An attacker can make a browser hit this URL with their own code, but
   // not with a state matching the signed cookie we set moments earlier.
-  if (!pending || pending.state !== state) return back(request, { error: "state" });
+  if (!pending || pending.state !== state) return back({ error: "state" });
 
   // A grant with nobody signed in is not something to salvage. Before Firebase
   // Auth this route had no prior identity to check against and simply believed
   // whatever the connector returned.
   const session = await getSession();
-  if (!session) return back(request, { error: "signin" }, pending.schoolId);
+  if (!session) return back({ error: "signin" }, pending.schoolId);
 
   const school = getSchool(pending.schoolId);
-  if (!school || school.status !== "live") return back(request, { error: "school" });
+  if (!school || school.status !== "live") return back({ error: "school" });
 
   let payload: { user_id?: string; email?: string; status?: string };
   try {
+    // The connector is a private Cloud Run service, so this call carries an
+    // OIDC token for the runtime service account. Without it Cloud Run answers
+    // 403 with an HTML page before the request ever reaches the connector, and
+    // the student sees `error=exchange` for a failure that is not an exchange.
+    const idToken = await connectorIdToken();
+
     // The connector exchanges the code using the client secret it holds and the
     // same redirect_uri that started the flow, then stores the refresh token.
     const res = await fetch(
       `${connectorBaseUrl()}/auth/callback?code=${encodeURIComponent(code)}`,
-      { cache: "no-store" },
+      {
+        cache: "no-store",
+        headers: idToken ? { Authorization: `Bearer ${idToken}` } : {},
+      },
     );
     if (!res.ok) {
       // Body may carry a Google error; it is not safe to show a student and not
       // useful to them either. Log it, show them something they can act on.
       console.error("connector /auth/callback failed", res.status, await res.text());
-      return back(request, { error: "exchange" }, school.id);
+      // 401/403 is Cloud Run turning us away at the door, not Google turning
+      // down the code. Told apart so the logs name the thing that is wrong.
+      const denied = res.status === 401 || res.status === 403;
+      if (denied) console.error("connector call was not authorised", { hadToken: Boolean(idToken) });
+      return back({ error: denied ? "unreachable" : "exchange" }, school.id);
     }
     payload = await res.json();
   } catch (err) {
     console.error("connector /auth/callback unreachable", err);
-    return back(request, { error: "unreachable" }, school.id);
+    return back({ error: "unreachable" }, school.id);
   }
 
   // The connector returns the Google `sub`. It is no longer our document key --
@@ -110,7 +126,7 @@ export async function GET(request: NextRequest) {
   // `/users/{user_id}/...` endpoints are addressed, so it is stored.
   const googleSub = payload.user_id;
   const email = payload.email?.toLowerCase();
-  if (!googleSub || !email) return back(request, { error: "exchange" }, school.id);
+  if (!googleSub || !email) return back({ error: "exchange" }, school.id);
 
   /*
    * School eligibility, and this is the check that actually enforces it.
@@ -121,7 +137,7 @@ export async function GET(request: NextRequest) {
    * address in this flow that is proven, so it is the only one worth testing.
    */
   if (!email.endsWith(`@${school.emailDomain}`)) {
-    return back(request, { error: "domain" }, school.id);
+    return back({ error: "domain" }, school.id);
   }
 
   /*
@@ -134,7 +150,7 @@ export async function GET(request: NextRequest) {
    * silently adopting the second is the wrong way to resolve that.
    */
   if (pending.email && email !== pending.email) {
-    return back(request, { error: "mismatch" }, school.id);
+    return back({ error: "mismatch" }, school.id);
   }
 
   // Adds what the grant proved to a document that already exists. It was
@@ -148,5 +164,5 @@ export async function GET(request: NextRequest) {
     schoolId: school.id,
   });
 
-  return back(request, { connected: "1" }, school.id);
+  return back({ connected: "1" }, school.id);
 }

--- a/src/frontend/lib/googleOAuth.ts
+++ b/src/frontend/lib/googleOAuth.ts
@@ -39,12 +39,63 @@ export const GOOGLE_SCOPES = [
   "https://www.googleapis.com/auth/drive.file",
 ] as const;
 
+/**
+ * This app's own public origin, with no trailing slash.
+ *
+ * Configured rather than derived, and that is the point. On Cloud Run the
+ * container is addressed as `0.0.0.0:8080` from inside, so anything built from
+ * the incoming request -- `request.nextUrl.origin`, the `Host` header -- yields
+ * that internal address and produces links no browser can follow. Only the
+ * deployment knows the public name, so only the deployment gets to say it.
+ */
+export function appBaseUrl(): string {
+  const base = process.env.NEXT_PUBLIC_APP_URL;
+  if (!base) throw new Error("NEXT_PUBLIC_APP_URL is not set");
+  return base.replace(/\/$/, "");
+}
+
 /** Where Google sends the student back. Must match the connector's
  *  OAUTH_REDIRECT_URI byte for byte, or the code exchange fails. */
 export function redirectUri(): string {
-  const base = process.env.NEXT_PUBLIC_APP_URL;
-  if (!base) throw new Error("NEXT_PUBLIC_APP_URL is not set");
-  return `${base.replace(/\/$/, "")}/onboarding/callback`;
+  return `${appBaseUrl()}/onboarding/callback`;
+}
+
+/**
+ * An identity token for calling the connector, or null when there is nobody to
+ * ask for one.
+ *
+ * The connector is a private Cloud Run service: it exchanges authorisation
+ * codes and writes refresh tokens to Secret Manager, so it is not something to
+ * leave open to the internet. Cloud Run authorises those calls with an OIDC
+ * token whose audience is the receiving service's URL, and on Cloud Run the
+ * metadata server mints one for the runtime service account for free -- no
+ * dependency, no key, nothing to rotate.
+ *
+ * Returns null off GCP, where there is no metadata server. That keeps local
+ * development running unauthenticated instead of crashing, and the connector's
+ * own 403 is a clearer report of that than a fetch error would be.
+ */
+export async function connectorIdToken(): Promise<string | null> {
+  const url =
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity" +
+    `?audience=${encodeURIComponent(connectorBaseUrl())}`;
+  try {
+    const res = await fetch(url, {
+      headers: { "Metadata-Flavor": "Google" },
+      cache: "no-store",
+      // Off GCP this name does not resolve, but a hostile DNS wildcard could
+      // make it hang. The call is to a link-local address when it is real.
+      signal: AbortSignal.timeout(2_000),
+    });
+    if (!res.ok) {
+      console.error("metadata identity token failed", res.status);
+      return null;
+    }
+    return (await res.text()).trim() || null;
+  } catch {
+    // No metadata server: local development.
+    return null;
+  }
 }
 
 export function clientId(): string {


### PR DESCRIPTION
Two independent faults behind the failed Google grant on the live site. Both are invisible in local development, which is why they shipped.

## 1. Every redirect out of the callback pointed at `0.0.0.0:8080`

`back()` built its URL from `request.nextUrl.origin`. On Cloud Run the container is addressed as `0.0.0.0:8080` from inside, so the student was sent to `https://0.0.0.0:8080/onboarding?...` — Safari reports "Not allowed to use restricted network port", which names neither the cause nor the fix.

This hit the **success** path too. A student who granted access perfectly still dead-ended on a browser error.

Now uses `appBaseUrl()` (`NEXT_PUBLIC_APP_URL`), the only source that knows the public name. Locally it is `http://localhost:3000`, so dev is unchanged.

## 2. `error=exchange` was never an exchange failure

The connector is a private Cloud Run service and the call carried no credentials, so Cloud Run rejected it at the door:

```
connector /auth/callback failed 403
<h2>Your client does not have permission to get URL /auth/callback?code=4/0ATsMZq…</h2>
```

That is Google's IAM page — the request never reached the connector, never reached Google, and had nothing to do with OAuth. The client ID and `OAUTH_REDIRECT_URI` were correct on both sides the whole time.

The call now carries an OIDC token from the Cloud Run metadata server, with `audience` set to the connector's base URL. No library, no key, nothing to rotate; returns `null` off GCP so local dev still runs. A 401/403 is now reported as `unreachable` and logged as an authorisation failure, so this cannot masquerade as a Google problem again.

### Infrastructure change (already applied)

`roles/run.invoker` on `classistant-connectors` for **`firebase-app-hosting-compute@classisstant.iam.gserviceaccount.com`** — the runtime compute account.

The service previously granted invoker only to `service-945345983057@gcp-sa-firebaseapphosting.iam.gserviceaccount.com`, which is App Hosting's **build-and-deploy service agent** and never makes runtime requests. It looks correct in the console and does nothing. `allUsers` was deliberately not restored: this endpoint exchanges auth codes and writes refresh tokens to Secret Manager.

`docs/design/12-onboarding-persistence.md` records both, including the warning about which service account is which.

🤖 Generated with [Claude Code](https://claude.com/claude-code)