### PR TITLE
Move the code exchange here, and envelope-encrypt credentials

### DIFF
--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -3,9 +3,13 @@
 # Production does not read this file: those values live in apphosting.yaml, with
 # secrets referenced by name out of Secret Manager.
 #
-# Nothing here is a secret. The client id is shipped to every browser in the
-# consent link, the URLs are public, and SESSION_SECRET below is a value you
+# Almost nothing here is a secret: the client id is shipped to every browser in
+# the consent link, the URLs are public, and SESSION_SECRET is a value you
 # generate for your own machine.
+#
+# GOOGLE_CLIENT_SECRET is the exception, and it is the one line in your
+# .env.local that genuinely must not be shared or pasted anywhere. It is left
+# blank here on purpose.
 
 # HMAC key for the onboarding cookie (lib/onboardingSession.ts). It no longer
 # signs the session: identity is a Firebase Auth session cookie now, so this
@@ -31,6 +35,22 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 # Public half of the OAuth client, same value as apphosting.yaml.
 NEXT_PUBLIC_GOOGLE_CLIENT_ID=945345983057-v45ksbfcu1epohvq1cb1asfqvfp3u9ek.apps.googleusercontent.com
+
+# The secret half. Needed once the code exchange runs on this server, because
+# Google requires client authentication on that call.
+#
+# Get it from Secret Manager rather than from the Cloud console, so you get the
+# same version production uses:
+#   gcloud secrets versions access latest --secret=oauth-client-secret \
+#     --project=classisstant
+#
+# That needs roles/secretmanager.secretAccessor on the secret; project Editor is
+# NOT enough, because Editor deliberately excludes secret payloads. If it denies
+# you, ask for the role rather than pasting the value through chat.
+#
+# Never prefix this NEXT_PUBLIC_. Next inlines NEXT_PUBLIC_* into the client
+# bundle, which would publish the client secret to every visitor.
+GOOGLE_CLIENT_SECRET=
 
 # The connector performs the code exchange and holds the client secret.
 #

--- a/src/frontend/app/onboarding/callback/route.ts
+++ b/src/frontend/app/onboarding/callback/route.ts
@@ -2,7 +2,13 @@ import { NextResponse, type NextRequest } from "next/server";
 
 import { getSchool } from "@/data/schools";
 import { getSession } from "@/lib/authSession";
-import { appBaseUrl, connectorBaseUrl, connectorIdToken } from "@/lib/googleOAuth";
+import { storeCredential } from "@/lib/credentials";
+import {
+  GrantError,
+  appBaseUrl,
+  exchangeCode,
+  type GoogleGrant,
+} from "@/lib/googleOAuth";
 import { takePendingOAuth } from "@/lib/onboardingSession";
 import { recordGoogleConnection } from "@/lib/users";
 
@@ -88,45 +94,34 @@ export async function GET(request: NextRequest) {
   const school = getSchool(pending.schoolId);
   if (!school || school.status !== "live") return back({ error: "school" });
 
-  let payload: { user_id?: string; email?: string; status?: string };
+  /*
+   * The code exchange, which this route now performs itself.
+   *
+   * It used to be a call to the connector, which held the client secret and
+   * wrote the refresh token to Secret Manager. Both halves of that have moved:
+   * the secret is mounted here (apphosting.yaml) and the token is sealed into
+   * Firestore below. The connector's job is now reading credentials, not
+   * minting them -- docs/ENCRYPTION_CONTRACT.md §1.
+   *
+   * The authorization code still never reaches the browser, and the refresh
+   * token now never reaches it either: it exists in this process only long
+   * enough to be encrypted.
+   */
+  let grant: GoogleGrant;
   try {
-    // The connector is a private Cloud Run service, so this call carries an
-    // OIDC token for the runtime service account. Without it Cloud Run answers
-    // 403 with an HTML page before the request ever reaches the connector, and
-    // the student sees `error=exchange` for a failure that is not an exchange.
-    const idToken = await connectorIdToken();
-
-    // The connector exchanges the code using the client secret it holds and the
-    // same redirect_uri that started the flow, then stores the refresh token.
-    const res = await fetch(
-      `${connectorBaseUrl()}/auth/callback?code=${encodeURIComponent(code)}`,
-      {
-        cache: "no-store",
-        headers: idToken ? { Authorization: `Bearer ${idToken}` } : {},
-      },
-    );
-    if (!res.ok) {
-      // Body may carry a Google error; it is not safe to show a student and not
-      // useful to them either. Log it, show them something they can act on.
-      console.error("connector /auth/callback failed", res.status, await res.text());
-      // 401/403 is Cloud Run turning us away at the door, not Google turning
-      // down the code. Told apart so the logs name the thing that is wrong.
-      const denied = res.status === 401 || res.status === 403;
-      if (denied) console.error("connector call was not authorised", { hadToken: Boolean(idToken) });
-      return back({ error: denied ? "unreachable" : "exchange" }, school.id);
-    }
-    payload = await res.json();
+    grant = await exchangeCode(code);
   } catch (err) {
-    console.error("connector /auth/callback unreachable", err);
-    return back({ error: "unreachable" }, school.id);
+    // GrantError already carries a message naming which half failed. Nothing
+    // logged here contains a token: on every error path Google's response
+    // carries a reason and no credential.
+    const reason = err instanceof GrantError ? err.code : "exchange";
+    console.error("google code exchange failed", reason, (err as Error)?.message);
+    return back({ error: reason }, school.id);
   }
 
-  // The connector returns the Google `sub`. It is no longer our document key --
-  // see the header of lib/users.ts -- but it is still how the connector's own
-  // `/users/{user_id}/...` endpoints are addressed, so it is stored.
-  const googleSub = payload.user_id;
-  const email = payload.email?.toLowerCase();
-  if (!googleSub || !email) return back({ error: "exchange" }, school.id);
+  // `sub` is no longer our document key -- see the header of lib/users.ts --
+  // but it is still worth keeping on the user document.
+  const { sub: googleSub, email } = grant;
 
   /*
    * School eligibility, and this is the check that actually enforces it.
@@ -137,6 +132,7 @@ export async function GET(request: NextRequest) {
    * address in this flow that is proven, so it is the only one worth testing.
    */
   if (!email.endsWith(`@${school.emailDomain}`)) {
+    await discard(grant);
     return back({ error: "domain" }, school.id);
   }
 
@@ -150,7 +146,31 @@ export async function GET(request: NextRequest) {
    * silently adopting the second is the wrong way to resolve that.
    */
   if (pending.email && email !== pending.email) {
+    await discard(grant);
     return back({ error: "mismatch" }, school.id);
+  }
+
+  /*
+   * Seal the refresh token before anything else is written.
+   *
+   * This is the order the contract asks for (§6) and the order that fails
+   * safely: if encryption or the KMS wrap throws, nothing has been recorded and
+   * the student simply retries. The reverse -- marking the account connected
+   * and then failing to store the credential -- would leave a user document
+   * claiming access that the agent cannot actually exercise, and it would fail
+   * at 3am with nothing pointing at the cause.
+   */
+  try {
+    await storeCredential({
+      uid: session.uid,
+      type: "google_refresh_token",
+      plaintext: grant.refreshToken,
+    });
+  } catch (err) {
+    // Never log the error object raw here: it is the one code path where a
+    // token is in scope, and a stack trace can carry arguments with it.
+    console.error("could not store the refresh token", (err as Error)?.message);
+    return back({ error: "exchange" }, school.id);
   }
 
   // Adds what the grant proved to a document that already exists. It was
@@ -165,4 +185,31 @@ export async function GET(request: NextRequest) {
   });
 
   return back({ connected: "1" }, school.id);
+}
+
+/**
+ * Hands a rejected grant back to Google.
+ *
+ * Reached when the exchange succeeded but the account turned out to be one we
+ * will not serve -- the wrong domain, or a different address than the student
+ * said. Not storing the token is not sufficient on its own: the student granted
+ * Gmail and Drive access to this application at Google, and dropping our copy
+ * would leave that grant standing on their account with nothing to show for it.
+ * Revoking is the only way to actually give it back.
+ *
+ * Best effort by design. A failure here must not change what the student sees,
+ * because the reason they are being turned away is already the more useful
+ * message and there is nothing they could do about a revoke that did not land.
+ */
+async function discard(grant: GoogleGrant): Promise<void> {
+  try {
+    await fetch("https://oauth2.googleapis.com/revoke", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      cache: "no-store",
+      body: new URLSearchParams({ token: grant.refreshToken }),
+    });
+  } catch (err) {
+    console.error("could not revoke a rejected grant", (err as Error)?.message);
+  }
 }

--- a/src/frontend/apphosting.yaml
+++ b/src/frontend/apphosting.yaml
@@ -17,15 +17,31 @@ env:
     value: https://classistant--classisstant.us-central1.hosted.app
     availability: [BUILD, RUNTIME]
 
-  # Public half of the OAuth client. Safe to commit; the secret half is mounted
-  # into the connector service on Cloud Run and never reaches this app.
+  # Public half of the OAuth client. Safe to commit -- it is in the consent link
+  # every browser follows. The secret half is the entry below.
   - variable: NEXT_PUBLIC_GOOGLE_CLIENT_ID
     value: 945345983057-v45ksbfcu1epohvq1cb1asfqvfp3u9ek.apps.googleusercontent.com
     availability: [BUILD, RUNTIME]
 
-  # Server-to-server only. Deliberately not NEXT_PUBLIC_: the connector is
-  # currently deployed --allow-unauthenticated, so there is no reason to hand
-  # its address to every browser as well.
+  # The secret half, by name. Needed here because the authorization-code
+  # exchange runs on this server: Google requires client authentication on that
+  # call, and the connector no longer performs it.
+  #
+  # RUNTIME only, and never NEXT_PUBLIC_. Next inlines NEXT_PUBLIC_* into the
+  # client bundle at build time, so that prefix on this variable would publish
+  # the client secret to every visitor.
+  #
+  # `firebase-app-hosting-compute@` reads it via roles/secretmanager.admin held
+  # at project level. If that binding ever goes, this app stops booting rather
+  # than starting without it -- the same startup abort the connector hit on
+  # 2026-08-27, which surfaced as a generic Cloud Run 500.
+  - variable: GOOGLE_CLIENT_SECRET
+    secret: oauth-client-secret
+    availability: [RUNTIME]
+
+  # Server-to-server only, and deliberately not NEXT_PUBLIC_: the connector is a
+  # private Cloud Run service reached with an OIDC token (see the callback), so
+  # its address has no business in a browser.
   - variable: CONNECTORS_API_URL
     value: https://classistant-connectors-945345983057.us-central1.run.app
     availability: [RUNTIME]

--- a/src/frontend/lib/credentials.ts
+++ b/src/frontend/lib/credentials.ts
@@ -1,0 +1,189 @@
+import "server-only";
+
+import { KeyManagementServiceClient } from "@google-cloud/kms";
+
+import { firestore } from "@/lib/firebaseAdmin";
+import {
+  generateDataKey,
+  generateIv,
+  sealWithDataKey,
+  toBase64,
+} from "@/lib/envelope";
+import { setStampedRef } from "@/lib/users";
+
+/**
+ * The outer layer of the credential envelope, and the write to Firestore.
+ *
+ * Implements §2, §5 and §6 of docs/ENCRYPTION_CONTRACT.md. The inner AES layer
+ * is in lib/envelope.ts, which is isomorphic; everything here needs a service
+ * account and so is server-only.
+ *
+ * The security property this file is responsible for is an absence: this app
+ * holds `cryptoKeyEncrypter` on both keys and `cryptoKeyDecrypter` on neither,
+ * so there is deliberately no `unwrapDataKey` below and no way to add one that
+ * would work. The frontend can lock a credential away and cannot open it again.
+ * Reading is the connector's job for refresh tokens, and the agent's for school
+ * passwords, each holding decrypt on one key only (contract §1).
+ */
+
+/**
+ * Which KMS key wraps which credential, and this mapping is the separation.
+ *
+ * Two keys rather than one is the whole reason the connector cannot read a
+ * school password: it holds decrypt on `classistant-key` alone, so a password
+ * wrapped under `classistant-password-key` is unreadable to it no matter what
+ * bug or compromise it suffers. Sending both through one key would collapse
+ * that guarantee into a code review promise.
+ */
+const KEY_FOR: Record<CredentialType, string> = {
+  google_refresh_token: "classistant-key",
+  school_password: "classistant-password-key",
+};
+
+export type CredentialType = "google_refresh_token" | "school_password";
+
+const KMS_LOCATION = "us-central1";
+const KMS_KEYRING = "classistant-keyring";
+
+/**
+ * Whether to bind each wrapped data key to one student with AAD.
+ *
+ * Contract §5. This must match `KMS_AAD_SOURCE` on the connector exactly: KMS
+ * fails closed when the AAD replayed at decrypt differs from the one supplied
+ * at encrypt, so a disagreement here is a total, silent read failure rather
+ * than a degraded one. It is a constant and not configuration for that reason
+ * -- an env var would let the two sides drift apart at deploy time, which is
+ * the one way this can break in production and not in a test.
+ *
+ * On, because it costs one argument and it stops an attacker who can write
+ * Firestore from moving user A's wrapped key into user B's document.
+ */
+const USE_AAD = true;
+
+let kms: KeyManagementServiceClient | undefined;
+
+function kmsClient(): KeyManagementServiceClient {
+  kms ??= new KeyManagementServiceClient();
+  return kms;
+}
+
+function projectId(): string {
+  const id = process.env.GOOGLE_CLOUD_PROJECT ?? process.env.GCLOUD_PROJECT;
+  if (!id) throw new Error("GOOGLE_CLOUD_PROJECT is not set");
+  return id;
+}
+
+function keyName(type: CredentialType): string {
+  return kmsClient().cryptoKeyPath(
+    projectId(),
+    KMS_LOCATION,
+    KMS_KEYRING,
+    KEY_FOR[type],
+  );
+}
+
+/** What §3 says a credential document holds, minus the timestamps Firestore
+ *  stamps itself. */
+export type SealedCredential = {
+  user_id: string;
+  credential_type: CredentialType;
+  encrypted_credential: string;
+  encrypted_dkey: string;
+  iv: string;
+};
+
+/**
+ * Wraps a data key with Cloud KMS.
+ *
+ * Two details here are contract, not preference, and both are invisible
+ * failures if got wrong:
+ *
+ * The plaintext handed to KMS is the base64 *text* of the key bytes, encoded
+ * UTF-8 -- not the 32 raw bytes. The connector base64-decodes what it gets back
+ * (issue #12 step 2), so raw bytes would unwrap to something 24 bytes long and
+ * fail as an AES key length error, pointing at the wrong layer entirely.
+ *
+ * The AAD is the uid as UTF-8. See USE_AAD above.
+ */
+async function wrapDataKey(
+  dkey: Uint8Array,
+  uid: string,
+  type: CredentialType,
+): Promise<Uint8Array> {
+  const [result] = await kmsClient().encrypt({
+    name: keyName(type),
+    plaintext: Buffer.from(toBase64(dkey), "utf8"),
+    ...(USE_AAD ? { additionalAuthenticatedData: Buffer.from(uid, "utf8") } : {}),
+  });
+
+  if (!result.ciphertext) throw new Error("KMS returned no ciphertext");
+  // The generated client types this as string | Uint8Array: it is bytes over
+  // gRPC and base64 text over REST, and which one arrives depends on transport
+  // rather than on anything this code chooses.
+  return typeof result.ciphertext === "string"
+    ? new Uint8Array(Buffer.from(result.ciphertext, "base64"))
+    : new Uint8Array(result.ciphertext);
+}
+
+/**
+ * Seals one credential into the three stored fields. No Firestore write.
+ *
+ * Split out from `storeCredential` so the bytes can be checked in a test
+ * without a database, and so a caller that already has a ciphertext from the
+ * browser -- which is where a school password should be sealed, since it is
+ * typed there and need never leave in the clear -- can wrap and store without
+ * going through this.
+ */
+export async function sealCredential(args: {
+  uid: string;
+  type: CredentialType;
+  plaintext: string;
+}): Promise<SealedCredential> {
+  const dkey = generateDataKey();
+  const iv = generateIv();
+
+  // Contract §6: encrypt first, write second. Nothing is persisted until every
+  // one of these has succeeded, so a failure leaves no half-written document
+  // promising a credential that is not there.
+  const sealed = await sealWithDataKey(args.plaintext, dkey, iv);
+  const wrapped = await wrapDataKey(dkey, args.uid, args.type);
+
+  // Best effort, and worth doing even though it is not a guarantee: V8 may
+  // have copied these bytes elsewhere, but the copy this code controls should
+  // not outlive the ciphertext.
+  dkey.fill(0);
+
+  return {
+    user_id: args.uid,
+    credential_type: args.type,
+    encrypted_credential: toBase64(sealed),
+    encrypted_dkey: toBase64(wrapped),
+    iv: toBase64(iv),
+  };
+}
+
+/** `users/{uid}/credentials/{credential_type}` -- contract §2. A subcollection,
+ *  so deleting a student is one recursive delete and the connector's read is a
+ *  direct document get with no query and no index. */
+function credentialRef(uid: string, type: CredentialType) {
+  return firestore()
+    .collection("users")
+    .doc(uid)
+    .collection("credentials")
+    .doc(type);
+}
+
+/**
+ * Seals a credential and writes it. The only function onboarding should call.
+ *
+ * `created_at` is stamped on insert only, so a student who re-onboards or
+ * changes a password keeps their original date (contract §6).
+ */
+export async function storeCredential(args: {
+  uid: string;
+  type: CredentialType;
+  plaintext: string;
+}): Promise<void> {
+  const doc = await sealCredential(args);
+  await setStampedRef(credentialRef(args.uid, args.type), doc);
+}

--- a/src/frontend/lib/envelope.test.ts
+++ b/src/frontend/lib/envelope.test.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { test } from "node:test";
+
+import {
+  IV_BYTES,
+  fromBase64,
+  generateDataKey,
+  generateIv,
+  openWithDataKey,
+  sealWithDataKey,
+  toBase64,
+} from "./envelope";
+
+/**
+ * Byte-compatibility with the connector, which is written in Python.
+ *
+ * These are not tests of AES -- Web Crypto and `cryptography` are both fine
+ * implementations and neither needs verifying here. They test the parts of
+ * docs/ENCRYPTION_CONTRACT.md that are *conventions* rather than algorithms,
+ * and that therefore have no way of announcing themselves when they disagree:
+ * whether the authentication tag is appended, how the IV is encoded, and what
+ * form the data key takes on its way to KMS.
+ *
+ * Each of those failures surfaces at the far end as "authentication failed",
+ * hours later, on a machine nobody is watching. Cross-checking against the
+ * actual Python library is the only way to find them at this end instead.
+ *
+ * The Python tests skip themselves if `cryptography` is absent, so a machine
+ * without it still gets the rest of the suite rather than a red build.
+ */
+
+function python(script: string, input: string): string {
+  return execFileSync("python3", ["-c", script], {
+    input,
+    encoding: "utf8",
+  }).trim();
+}
+
+function hasPython(): boolean {
+  try {
+    python("import cryptography", "");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const pythonAvailable = hasPython();
+const skipPython = pythonAvailable
+  ? false
+  : "python3 with `cryptography` not available";
+
+test("round trips through its own implementation", async () => {
+  const dkey = generateDataKey();
+  const iv = generateIv();
+  const message = "café 日本語 — unicode survives the trip";
+
+  const sealed = await sealWithDataKey(message, dkey, iv);
+  assert.equal(await openWithDataKey(sealed, dkey, iv), message);
+});
+
+test("appends the 16-byte GCM tag to the ciphertext", async () => {
+  const message = "0123456789";
+  const sealed = await sealWithDataKey(message, generateDataKey(), generateIv());
+
+  // Contract §4: the stored value is ciphertext || tag. GCM is a stream mode,
+  // so the ciphertext is exactly the plaintext length and the whole of the
+  // remainder is the tag. If this is 0, the tag was dropped.
+  assert.equal(sealed.length - message.length, 16);
+});
+
+test("uses a 96-bit IV and a 256-bit key", () => {
+  assert.equal(generateIv().length, 12);
+  assert.equal(IV_BYTES, 12);
+  assert.equal(generateDataKey().length, 32);
+});
+
+test("never produces the same IV or key twice", () => {
+  const ivs = new Set(Array.from({ length: 200 }, () => toBase64(generateIv())));
+  const keys = new Set(
+    Array.from({ length: 200 }, () => toBase64(generateDataKey())),
+  );
+  assert.equal(ivs.size, 200, "IV repeated — GCM is broken by IV reuse");
+  assert.equal(keys.size, 200);
+});
+
+test("rejects a wrong-sized key or IV rather than producing bad bytes", async () => {
+  await assert.rejects(
+    () => sealWithDataKey("x", new Uint8Array(16), generateIv()),
+    /dkey must be 32 bytes/,
+  );
+  await assert.rejects(
+    () => sealWithDataKey("x", generateDataKey(), new Uint8Array(16)),
+    /iv must be 12 bytes/,
+  );
+});
+
+test("fails closed when the ciphertext is tampered with", async () => {
+  const dkey = generateDataKey();
+  const iv = generateIv();
+  const sealed = await sealWithDataKey("do not modify", dkey, iv);
+  sealed[0] ^= 0xff;
+
+  await assert.rejects(() => openWithDataKey(sealed, dkey, iv));
+});
+
+test("base64 helpers round trip arbitrary bytes", () => {
+  const bytes = crypto.getRandomValues(new Uint8Array(1024));
+  assert.deepEqual(fromBase64(toBase64(bytes)), bytes);
+});
+
+test(
+  "Python's AESGCM decrypts what we seal — the connector's read path",
+  { skip: skipPython },
+  async () => {
+    const dkey = generateDataKey();
+    const iv = generateIv();
+    const message = "super-secret-refresh-token-value";
+    const sealed = await sealWithDataKey(message, dkey, iv);
+
+    // Exactly the call in the connector and in scripts/seed_credential.py:
+    // AESGCM over ciphertext||tag, with no AAD on this layer.
+    const decrypted = python(
+      `
+import sys, json, base64
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+d = json.load(sys.stdin)
+print(AESGCM(base64.b64decode(d["dkey"])).decrypt(
+    base64.b64decode(d["iv"]), base64.b64decode(d["ct"]), None).decode())
+`,
+      JSON.stringify({
+        dkey: toBase64(dkey),
+        iv: toBase64(iv),
+        ct: toBase64(sealed),
+      }),
+    );
+
+    assert.equal(decrypted, message);
+  },
+);
+
+test(
+  "we decrypt what Python's AESGCM seals",
+  { skip: skipPython },
+  async () => {
+    const message = "password-from-python";
+    const payload = JSON.parse(
+      python(
+        `
+import os, base64, json
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+dkey, iv = os.urandom(32), os.urandom(12)
+ct = AESGCM(dkey).encrypt(iv, ${JSON.stringify(message)}.encode("utf-8"), None)
+print(json.dumps({"dkey": base64.b64encode(dkey).decode(),
+                  "iv": base64.b64encode(iv).decode(),
+                  "ct": base64.b64encode(ct).decode()}))
+`,
+        "",
+      ),
+    ) as { dkey: string; iv: string; ct: string };
+
+    assert.equal(
+      await openWithDataKey(
+        fromBase64(payload.ct),
+        fromBase64(payload.dkey),
+        fromBase64(payload.iv),
+      ),
+      message,
+    );
+  },
+);
+
+test(
+  "the KMS plaintext is the base64 TEXT of the key, matching Python",
+  { skip: skipPython },
+  () => {
+    // Contract §5, and the failure mode that makes it worth a test: sending the
+    // 32 raw bytes instead unwraps on the connector to 24 bytes after its
+    // base64 decode, and surfaces as an AES key-length error pointing at the
+    // wrong layer entirely.
+    const dkey = new Uint8Array(32).map((_, i) => (i * 7 + 3) & 0xff);
+    const ours = Buffer.from(toBase64(dkey), "utf8");
+
+    const theirs = python(
+      `
+import sys, base64
+dkey = bytes((i*7+3)&0xff for i in range(32))
+sys.stdout.write(base64.b64encode(base64.b64encode(dkey)).decode())
+`,
+      "",
+    );
+
+    assert.equal(ours.toString("base64"), theirs);
+    assert.equal(ours.length, 44, "base64 of 32 bytes is 44 characters");
+  },
+);

--- a/src/frontend/lib/envelope.ts
+++ b/src/frontend/lib/envelope.ts
@@ -1,0 +1,147 @@
+/**
+ * The inner layer of the credential envelope: AES-256-GCM over one credential.
+ *
+ * Implements §4 of docs/ENCRYPTION_CONTRACT.md, which the connector's read path
+ * is written against. Every constant here is part of that contract rather than
+ * a local choice, so none of them may be "tidied": a change to the key length,
+ * the IV length, or the byte order of the output is a silent decrypt failure on
+ * the other side of the system, reported as an authentication tag mismatch with
+ * nothing naming the cause.
+ *
+ * Deliberately NOT `server-only`, and deliberately free of Node built-ins.
+ *
+ * The two credentials this protects are produced in different places. A school
+ * password is typed into the browser, so it can and should be sealed there and
+ * only ever travel as ciphertext. A Google refresh token is the product of a
+ * server-side code exchange and never exists in the browser at all -- shipping
+ * one to the client in order to encrypt it "on device" would be strictly worse
+ * than sealing it on the server. Both cases need identical bytes, so this file
+ * uses Web Crypto, which is the one AES-GCM implementation present in both.
+ *
+ * Web Crypto also removes the single most likely way to get §4 wrong. Node's
+ * `createCipheriv` hands back the ciphertext and the 16-byte authentication tag
+ * as two separate values, and Python's `AESGCM.decrypt` -- what the connector
+ * calls -- will only accept them concatenated. `crypto.subtle.encrypt` returns
+ * them already joined in that order, so the mistake cannot be made here.
+ */
+
+/** AES-256. Contract §4. */
+const DKEY_BYTES = 32;
+
+/** 96-bit, the GCM standard length and what the connector assumes. Contract §4. */
+export const IV_BYTES = 12;
+
+/** GCM's authentication tag, in bits, as Web Crypto wants it. 16 bytes. */
+const TAG_BITS = 128;
+
+/** A fresh AES-256 data key. One per credential, never reused, never stored
+ *  unwrapped -- `wrapDataKey` in lib/credentials.ts is what it goes on to. */
+export function generateDataKey(): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(DKEY_BYTES));
+}
+
+/**
+ * A fresh IV. Contract §4: one per *write*, never reused with a key.
+ *
+ * Reusing an IV under the same key does not weaken GCM slightly, it breaks it:
+ * two messages under one key/IV pair leak their XOR and can forge the
+ * authentication tag. Since a fresh `dkey` is generated per credential anyway
+ * this is belt and braces, and it stays that way.
+ */
+export function generateIv(): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(IV_BYTES));
+}
+
+/**
+ * Seals one credential, returning `ciphertext || tag` exactly as §4 requires.
+ *
+ * No additional authenticated data on this layer -- the reference
+ * implementation passes `None`, and the binding to a specific student is done
+ * one layer out, as AAD on the KMS wrap of the data key.
+ */
+export async function sealWithDataKey(
+  plaintext: string,
+  dkey: Uint8Array,
+  iv: Uint8Array,
+): Promise<Uint8Array> {
+  if (dkey.length !== DKEY_BYTES) {
+    throw new Error(`dkey must be ${DKEY_BYTES} bytes, got ${dkey.length}`);
+  }
+  if (iv.length !== IV_BYTES) {
+    throw new Error(`iv must be ${IV_BYTES} bytes, got ${iv.length}`);
+  }
+
+  const key = await crypto.subtle.importKey("raw", toBuffer(dkey), "AES-GCM", false, [
+    "encrypt",
+  ]);
+  const sealed = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: toBuffer(iv), tagLength: TAG_BITS },
+    key,
+    new TextEncoder().encode(plaintext),
+  );
+  return new Uint8Array(sealed);
+}
+
+/**
+ * The inverse, for tests only.
+ *
+ * Nothing in this application decrypts a credential: the frontend holds
+ * `cryptoKeyEncrypter` and not `cryptoKeyDecrypter`, and that asymmetry is the
+ * whole security property (contract §1). This exists so the round trip can be
+ * proven in a test, and it takes the data key as an argument -- there is no
+ * path from here to a stored credential, because there is no path from here to
+ * an unwrapped data key.
+ */
+export async function openWithDataKey(
+  sealed: Uint8Array,
+  dkey: Uint8Array,
+  iv: Uint8Array,
+): Promise<string> {
+  const key = await crypto.subtle.importKey("raw", toBuffer(dkey), "AES-GCM", false, [
+    "decrypt",
+  ]);
+  const plain = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: toBuffer(iv), tagLength: TAG_BITS },
+    key,
+    toBuffer(sealed),
+  );
+  return new TextDecoder().decode(plain);
+}
+
+/**
+ * base64, without Node's Buffer so this stays usable in the browser.
+ *
+ * Chunked because `String.fromCharCode(...bytes)` spreads every byte into an
+ * argument list and blows the call stack on large inputs. Credentials are
+ * small, but this is the kind of limit that is discovered by a user rather than
+ * by a test.
+ */
+export function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary);
+}
+
+export function fromBase64(text: string): Uint8Array {
+  const binary = atob(text);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/**
+ * A plain ArrayBuffer view of a byte array.
+ *
+ * `Uint8Array` may sit at an offset inside a larger buffer, and handing its
+ * `.buffer` to Web Crypto would silently encrypt the whole underlying region.
+ * Slicing is the cheap way to be certain the bytes passed are the bytes meant.
+ */
+function toBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  ) as ArrayBuffer;
+}

--- a/src/frontend/lib/googleOAuth.ts
+++ b/src/frontend/lib/googleOAuth.ts
@@ -104,6 +104,148 @@ export function clientId(): string {
   return id;
 }
 
+/**
+ * The secret half, which only ever exists on this side of the network.
+ *
+ * Read through a function rather than at module scope so a missing value fails
+ * on the request that needs it, naming itself, instead of at import time where
+ * it would take the whole route down with a stack trace that points at a bundle.
+ */
+function clientSecret(): string {
+  const secret = process.env.GOOGLE_CLIENT_SECRET;
+  if (!secret) throw new Error("GOOGLE_CLIENT_SECRET is not set");
+  return secret;
+}
+
+/** An error the callback can turn into one of the wizard's messages, rather
+ *  than a generic failure. `code` matches the keys in OAUTH_ERRORS. */
+export class GrantError extends Error {
+  constructor(
+    readonly code: "exchange" | "unreachable" | "incomplete",
+    message: string,
+  ) {
+    super(message);
+    this.name = "GrantError";
+  }
+}
+
+/** What the exchange proves. Nothing here is stored raw: the refresh token goes
+ *  straight into the envelope (lib/credentials.ts) and is never logged. */
+export type GoogleGrant = {
+  refreshToken: string;
+  /** Google's stable subject id. */
+  sub: string;
+  /** Lowercased, and the only address in this flow Google has actually
+   *  vouched for -- the one typed on the school step is just a claim. */
+  email: string;
+};
+
+/**
+ * Trades the authorization code for tokens. This is the step that used to
+ * happen in the connector.
+ *
+ * It moved here because the connector no longer runs sign-in at all: it reads
+ * credentials and calls Google APIs, and the code exchange is the one part of
+ * that which belongs to whoever started the flow. See docs/ENCRYPTION_CONTRACT.md
+ * §1, and docs/design/12 for why the frontend already owned the consent URL.
+ *
+ * `redirect_uri` is required by Google even though nothing is being redirected
+ * here: it must byte-match the one that started the flow, and is what stops a
+ * code stolen from one client being redeemed by another.
+ */
+export async function exchangeCode(code: string): Promise<GoogleGrant> {
+  let res: Response;
+  try {
+    res = await fetch("https://oauth2.googleapis.com/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      cache: "no-store",
+      body: new URLSearchParams({
+        code,
+        client_id: clientId(),
+        client_secret: clientSecret(),
+        redirect_uri: redirectUri(),
+        grant_type: "authorization_code",
+      }),
+    });
+  } catch (err) {
+    throw new GrantError("unreachable", `token endpoint unreachable: ${err}`);
+  }
+
+  // Google returns its reason in the body, and it is worth having in the log:
+  // `invalid_grant` is a spent or expired code, `invalid_client` is our own
+  // credentials being wrong, and treating those two as one failure is what
+  // sends someone looking in the wrong place. The body carries no token on any
+  // error path, so it is safe to keep.
+  const payload = (await res.json().catch(() => ({}))) as {
+    refresh_token?: string;
+    id_token?: string;
+    error?: string;
+    error_description?: string;
+  };
+
+  if (!res.ok) {
+    throw new GrantError(
+      "exchange",
+      `google refused the code: ${payload.error ?? res.status} ${payload.error_description ?? ""}`,
+    );
+  }
+
+  if (!payload.id_token) {
+    throw new GrantError("incomplete", "no id_token in the token response");
+  }
+
+  /*
+   * No refresh token means the whole grant was pointless.
+   *
+   * Google only issues one when `access_type=offline` is on the consent URL,
+   * and only *re-issues* one on a repeat login when `prompt=consent` is too.
+   * Both are set in buildAuthUrl above and must stay: without a refresh token
+   * the agent cannot act overnight, which is the entire product. Failing loudly
+   * here beats writing a credential document with nothing useful in it.
+   */
+  if (!payload.refresh_token) {
+    throw new GrantError(
+      "incomplete",
+      "google returned no refresh_token (is prompt=consent still set?)",
+    );
+  }
+
+  const claims = decodeIdToken(payload.id_token);
+  if (!claims.sub || !claims.email) {
+    throw new GrantError("incomplete", "id_token carried no sub or email");
+  }
+
+  return {
+    refreshToken: payload.refresh_token,
+    sub: claims.sub,
+    email: claims.email.toLowerCase(),
+  };
+}
+
+/**
+ * Reads the claims out of an ID token without verifying its signature.
+ *
+ * That is deliberate and it is what the spec asks for here. OpenID Connect Core
+ * §3.1.3.7 allows TLS server validation to stand in for signature checking when
+ * the token came directly from the token endpoint, which is exactly this case:
+ * the response was fetched over TLS from accounts.google.com, in a request
+ * authenticated with our client secret, and nothing untrusted touched it in
+ * between. Verifying a signature against Google's JWKS would mean fetching and
+ * caching a key set to re-prove a fact TLS has already established.
+ *
+ * This must not be copied to anywhere that accepts an ID token *from a client*.
+ * There the signature is the only thing standing between you and a forged
+ * identity, and it has to be checked -- which is what firebase-admin's
+ * verifyIdToken does for the session route.
+ */
+function decodeIdToken(idToken: string): { sub?: string; email?: string } {
+  const payload = idToken.split(".")[1];
+  if (!payload) throw new GrantError("incomplete", "malformed id_token");
+  const json = Buffer.from(payload, "base64url").toString("utf8");
+  return JSON.parse(json) as { sub?: string; email?: string };
+}
+
 export function connectorBaseUrl(): string {
   const url = process.env.CONNECTORS_API_URL;
   if (!url) throw new Error("CONNECTORS_API_URL is not set");

--- a/src/frontend/lib/users.ts
+++ b/src/frontend/lib/users.ts
@@ -79,16 +79,12 @@ export type UserProfile = {
  * the ordering that consent evidence depends on. The transaction is what makes
  * "insert or update" actually mean it.
  */
-async function setStamped(
-  collection: string,
-  id: string,
+export async function setStampedRef(
+  ref: FirebaseFirestore.DocumentReference,
   data: FirebaseFirestore.DocumentData,
   onInsert: FirebaseFirestore.DocumentData = {},
 ): Promise<void> {
-  const db = firestore();
-  const ref = db.collection(collection).doc(id);
-
-  await db.runTransaction(async (tx) => {
+  await firestore().runTransaction(async (tx) => {
     const snap = await tx.get(ref);
     tx.set(
       ref,
@@ -102,6 +98,18 @@ async function setStamped(
       { merge: true },
     );
   });
+}
+
+/** The same write, addressed the way every caller in this file wants it. The
+ *  ref-taking form above exists because credential documents live in a
+ *  subcollection, which a collection-and-id pair cannot name. */
+async function setStamped(
+  collection: string,
+  id: string,
+  data: FirebaseFirestore.DocumentData,
+  onInsert: FirebaseFirestore.DocumentData = {},
+): Promise<void> {
+  await setStampedRef(firestore().collection(collection).doc(id), data, onInsert);
 }
 
 export async function upsertUser(profile: UserProfile): Promise<void> {

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "classistant-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@google-cloud/kms": "^5.7.0",
         "@google-cloud/secret-manager": "^6.3.0",
         "firebase": "^12.18.0",
         "firebase-admin": "^13.10.0",
@@ -23,6 +24,7 @@
         "@types/react-dom": "19.1.7",
         "postcss": "8.5.6",
         "tailwindcss": "4.1.13",
+        "tsx": "^4.23.12",
         "typescript": "5.8.3"
       }
     },
@@ -47,6 +49,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -834,6 +1278,18 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/kms": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/kms/-/kms-5.7.0.tgz",
+      "integrity": "sha512-bxsauk8eUHfFEY9kLIbEfjHYhT0/7K+gDAsSzoR1ob7WK2vO0PuXYqn0kIFxTC38+0wYXp5qYfZL1+xSPBxfnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-gax": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@google-cloud/paginator": {
@@ -2627,6 +3083,48 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2870,6 +3368,21 @@
       },
       "engines": {
         "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -4710,6 +5223,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typescript": {
       "version": "5.8.3",

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -7,9 +7,11 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test lib/*.test.ts"
   },
   "dependencies": {
+    "@google-cloud/kms": "^5.7.0",
     "@google-cloud/secret-manager": "^6.3.0",
     "firebase": "^12.18.0",
     "firebase-admin": "^13.10.0",
@@ -25,6 +27,7 @@
     "@types/react-dom": "19.1.7",
     "postcss": "8.5.6",
     "tailwindcss": "4.1.13",
+    "tsx": "^4.23.12",
     "typescript": "5.8.3"
   }
 }


### PR DESCRIPTION
Completes the frontend write path for `docs/ENCRYPTION_CONTRACT.md`, and unblocks `matthew/firestore-creds`.

Three commits, deliberately in this order: the crypto, then the config, then the rewiring.

## 1. The envelope (`lib/envelope.ts`, `lib/credentials.ts`)

AES-256-GCM inner layer, KMS-wrapped data key, written to `users/{uid}/credentials/{type}`.

`envelope.ts` uses **Web Crypto** rather than Node's `crypto`, for two reasons. It keeps the module usable in the browser, which is where a school password should be sealed since it is typed there. And `subtle.encrypt` returns `ciphertext || tag` already joined, so the concat mistake @MatthewA15 flagged cannot be made.

`credentials.ts` has **no unwrap function**, and no working one can be added: this app holds `cryptoKeyEncrypter` on both keys and `cryptoKeyDecrypter` on neither. The one-way guarantee is IAM, not code. Two keys, per §1 — a password wrapped under `classistant-password-key` stays unreadable to the connector.

## 2. The client secret (`apphosting.yaml`)

Mounted by name from `oauth-client-secret`, `RUNTIME` only and never `NEXT_PUBLIC_` (that prefix is inlined into the client bundle at build time, which would publish it to every visitor). No IAM needed — `firebase-app-hosting-compute@` already holds `roles/secretmanager.admin` at project level.

## 3. The exchange moves (`app/onboarding/callback/route.ts`)

The callback now redeems the code itself and seals the refresh token. The connector is no longer called.

- The refresh token exists between `exchangeCode` and `storeCredential` and nowhere else — not in a log, not in an error object, never in the browser.
- **Sealed before recorded** (§6). A user document marked connected with no credential behind it fails at 3am with nothing naming the cause.
- **Rejected grants are revoked.** Wrong domain or wrong address previously meant dropping our copy while leaving the Google-side grant standing on the student's account. Not storing a credential is not the same as not holding one.
- `decodeIdToken` deliberately does not verify the signature — OIDC Core §3.1.3.7 permits TLS server validation to stand in when the token comes straight from the token endpoint. The comment says why, and why it must never be copied to anywhere accepting a token *from a client*.

## Verification

| | |
|---|---|
| Python `AESGCM.decrypt` opens what we seal | pass |
| We open what Python's `AESGCM` seals | pass |
| KMS plaintext identical to `base64.b64encode(dkey)` | pass |
| Tag appended, tampering fails closed | pass |
| Real `kms.encrypt` call shape against `classistant-key` | pass (temp grant, since revoked) |
| `exchangeCode` against Google's real token endpoint | pass — `invalid_grant`, i.e. client auth accepted |

10 tests via `npm test`; three run the real Python library, so this is checked against the connector's behaviour rather than my reading of the prose.

## What is NOT verified

**`storeCredential` has never run as the App Hosting service account.** The IAM binding exists and the call shape is proven, but the KMS wrap plus Firestore write has not executed in production. **The first real onboarding is the test** — worth doing while someone is watching the logs. Revert + redeploy is the rollback.

## Sequencing

1. Merge this, onboard one student, confirm `users/{uid}/credentials/google_refresh_token` has all three fields and no plaintext.
2. @MatthewA15 points his read path at that document — that closes the last unproven link, since I hold encrypt and cannot decrypt.
3. Then `matthew/firestore-creds` is safe to merge.

Between 1 and 3 the deployed connector cannot read new users' credentials (they are in Firestore, it still reads Secret Manager). Nothing consumes them yet, so the window is harmless — but it is real, and it closes when his PR lands.

## Notes

- **AAD is ON**, `utf8(uid)`, KMS call only. Must match `KMS_AAD_SOURCE`. A constant rather than an env var so the two sides cannot drift at deploy time.
- `connectorIdToken` / `connectorBaseUrl` are now unused — the frontend no longer calls the connector. Left in place rather than deleted, since a frontend→connector call is likely to return and the OIDC-token handling was non-obvious to get right.
- `school_password` still goes to Secret Manager. Retiring that is §8 and involves the browser-side encryption question, so it is deliberately a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)