### PR TITLE
Stop settings() firing twice and failing every submit

### DIFF
--- a/src/frontend/lib/firebaseAdmin.ts
+++ b/src/frontend/lib/firebaseAdmin.ts
@@ -45,17 +45,52 @@ export function adminAuth(): Auth {
   return auth;
 }
 
-let db: Firestore | undefined;
+/**
+ * Cached on `globalThis`, not in a module variable, and that is the fix.
+ *
+ * Next compiles this module into several independent server bundles -- one for
+ * the page, one for server actions, others for route handlers -- and each gets
+ * its own copy of every module-scope variable. `getFirestore()` does NOT: it
+ * returns one instance per app, shared across all of them.
+ *
+ * So a plain `let db` looks like a singleton and is not. The page renders,
+ * finds its `db` empty, and configures the instance. The student submits, the
+ * action runs in a different bundle, finds *its* `db` empty, asks for the same
+ * already-used instance, and calls `settings()` on it a second time -- which
+ * throws `Firestore has already been initialized`.
+ *
+ * That is not a degraded path, it is a total one: every server action that
+ * touched Firestore after a page render failed, so onboarding could never be
+ * completed by anybody. It cost an evening to find because the symptom is a
+ * digest on a generic error page and the stack points at whichever bundle lost
+ * the race, never at this file.
+ */
+const firestoreCache = globalThis as typeof globalThis & {
+  __classistantFirestore?: Firestore;
+};
 
 export function firestore(): Firestore {
-  if (db) return db;
+  if (firestoreCache.__classistantFirestore) {
+    return firestoreCache.__classistantFirestore;
+  }
 
-  db = getFirestore(adminApp());
+  const instance = getFirestore(adminApp());
+
   // Firestore rejects undefined values by default, which turns an optional
   // field the wizard did not collect into a runtime throw halfway through
   // onboarding. Dropping them is the behaviour every write here wants.
-  db.settings({ ignoreUndefinedProperties: true });
-  return db;
+  try {
+    instance.settings({ ignoreUndefinedProperties: true });
+  } catch {
+    // Already configured, by an earlier bundle that won the race. The settings
+    // it applied are these ones -- this is the only place that calls settings()
+    // -- so the instance is correct and there is nothing to repair. Swallowed
+    // rather than rethrown because the alternative is failing a request over a
+    // setting that is already in force.
+  }
+
+  firestoreCache.__classistantFirestore = instance;
+  return instance;
 }
 
 // Re-exported so callers do not each import from firebase-admin directly.


### PR DESCRIPTION
`Digest: 1948753698` on the final step of onboarding. From the App Hosting logs:

```
⨯ Error: Firestore has already been initialized. You can only call settings()
  once, and only before calling any other methods on a Firestore object.
```

## Why

`lib/firebaseAdmin.ts` cached the Firestore handle in a module variable. Next compiles that module into **several independent server bundles** — one for the page, one for server actions, others for route handlers — and each gets its own copy of every module-scope variable. `getFirestore()` does not: it returns one instance per app, shared across all of them.

So `let db` looks like a singleton and isn't:

1. Page renders → its `db` is empty → `getFirestore()` → `settings()` → fine.
2. Student submits → action runs in a **different bundle** → *its* `db` is empty → same already-used instance → `settings()` again → **throws**.

## Impact

Not a degraded path — a total one. Every server action that touched Firestore after a page render failed, which means **`completeOnboarding` could never write anything**. That matches the database exactly: `onboarding_complete` has never been `true` for any user, and the `credentials` collection has always been empty. Nobody has ever finished onboarding, and this is why.

It survived this long because the symptom is a digest on a generic error page and the stack points at whichever bundle lost the race, never at this file.

## Fix

Cache on `globalThis` so the "already configured" fact is shared across bundles, and tolerate losing the race:

```ts
const firestoreCache = globalThis as typeof globalThis & { __classistantFirestore?: Firestore };
```

The `catch` is safe rather than a shrug: this is the only place that calls `settings()`, so an instance that rejects the call has already had *these* settings applied. Failing a request over a setting that is already in force would be the worse outcome.

## Verified both directions

| | |
|---|---|
| Two `settings()` calls on one instance | reproduces the exact error |
| Cache cleared, instance still configured | no longer throws, same instance returned |

Note `ignoreUndefinedProperties` is load-bearing, not cosmetic: `upsertUser` writes `service_email: profile.serviceEmail`, which is always `undefined` today. Without the setting in force, that write throws too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)