### PR TITLE
Seal the portal password, and retire Secret Manager

### DIFF
--- a/docs/design/12-onboarding-persistence.md
+++ b/docs/design/12-onboarding-persistence.md
@@ -218,6 +218,15 @@ stamps `created_at` only on insert.
 
 ## Why the portal password is in Secret Manager
 
+> **Superseded by [19 Portal password envelope](19-portal-password-envelope.md).**
+> The password is envelope-encrypted into
+> `users/{uid}/credentials/school_password` now, under `classistant-password-key`,
+> and Secret Manager is out of this path entirely. Two of the three reasons
+> below stopped being true when issue #12 moved refresh tokens out of Secret
+> Manager as well; 19 says which, and what replaced the third. The reasoning
+> below is kept because the trade it describes is still the right one to
+> understand, and because the conclusion changed for reasons outside it.
+
 This is **reversible encryption, not hashing**. The agent replays the password
 into the school's LMS overnight, so a one-way hash is not available to us the way
 it would be for a password we authenticate against ourselves.

--- a/docs/design/19-portal-password-envelope.md
+++ b/docs/design/19-portal-password-envelope.md
@@ -1,0 +1,152 @@
+# 19. The portal password, sealed
+
+The school portal password was never being written where the rest of the system
+expected to find it. Onboarding put it in Secret Manager and left a pointer in a
+top-level `credentials/{uid}` document, while the Google refresh token was going
+into `users/{uid}/credentials/google_refresh_token` as an envelope-encrypted
+blob. Two credentials, two stores, two audit stories.
+
+`docs/ENCRYPTION_CONTRACT.md` §8 already settled this on paper: the Secret
+Manager path is retired and the password follows the same envelope as the
+refresh token, under its own key. The code had the key mapping in it and no
+caller. This is the caller.
+
+```
+users/{uid}/credentials/school_password
+  user_id, credential_type, encrypted_credential, encrypted_dkey, iv,
+  created_at, updated_at
+```
+
+`encrypted_credential` is AES-256-GCM with the tag appended, `encrypted_dkey` is
+that message's data key wrapped by `classistant-password-key` in
+`classistant-keyring`, with the uid as additional authenticated data. Byte for
+byte the same scheme as the refresh token, and the same code path
+(`lib/credentials.ts`); the only thing that differs is which key does the wrap.
+
+## Doc 12 chose Secret Manager, and it was right at the time
+
+[12](12-onboarding-persistence.md) weighed Secret Manager against envelope
+encryption and picked Secret Manager for three reasons. Two of them stopped
+being true, and it is worth being precise about which:
+
+**"It is already how the connector stores per-user refresh tokens, so
+credentials have one storage model rather than two."** This was the strongest
+argument and it inverted completely. Issue #12 moved refresh tokens out of
+Secret Manager and into the Firestore envelope. Keeping the password behind
+Secret Manager is now the thing that creates two storage models, not the thing
+that avoids them.
+
+**"No key handling code of our own to get wrong."** Also gone, and not by
+choice: `lib/envelope.ts` and `lib/credentials.ts` exist and are load bearing
+for the refresh token. The code is written, reviewed, and cross-checked against
+the connector's Python. Declining to use it for the password buys nothing.
+
+**"Every individual read is audit logged."** This one still stands, and it is a
+real loss. Secret Manager logs every `AccessSecretVersion` by default; Firestore
+logs document reads only with Data Access audit logs enabled, at coarser
+granularity. What replaces it is a KMS log rather than a Firestore one: reading
+a password requires a `Decrypt` call on `classistant-password-key`, and KMS
+records those. That is arguably the better record anyway, because it is the
+step that cannot be skipped -- a reader with the ciphertext still has nothing.
+
+## What the envelope buys that Secret Manager did not
+
+The reason to be pleased about this rather than merely consistent:
+
+**The blast radius is a key, not a role.** A Secret Manager secret is readable
+by anything holding `secretAccessor` broadly enough to match its name, which is
+why doc 07 had to record a *conditioned* IAM binding on the connector to keep it
+out of `session-secret`. A sealed password is readable only by a principal with
+`cryptoKeyDecrypter` on one specific key, and the connector has no grant on that
+key at all. The separation is a KMS binding rather than a name prefix in an IAM
+condition.
+
+**It is bound to one student.** The KMS wrap passes the uid as AAD, so an
+attacker who can write Firestore cannot move student A's `encrypted_dkey` into
+student B's document -- KMS fails closed. Secret Manager had no equivalent; the
+binding was the secret's name, and names are guessable.
+
+**Cost stops scaling with students.** One secret per student bills per active
+version per month and there is a per-project quota. Doc 12 flagged this as the
+trade and said envelope encryption "is where this should go if that day
+arrives". The day arrived for a different reason.
+
+## Where the username went
+
+`users/{uid}.school_username`, not the credential document.
+
+It is not a credential. It is an identifier the school hands out, frequently the
+student number, and it belongs beside `school_id` and `email` where anything
+holding `datastore.viewer` can read it without being able to open anything.
+Putting it in the credential document would also add a field that
+ENCRYPTION_CONTRACT.md §3 does not list, and the connector checks that
+document's shape from the other side.
+
+This is one of the contract's open items ("where `school_username` lives"), so
+it is a decision made here rather than one being followed. The cost if it goes
+the other way is a field move.
+
+## Order of writes, and which half survives a failure
+
+The credential is sealed and written first, then the username. It is the same
+reasoning the Secret Manager version used with the destinations swapped: a
+sealed password nobody points at is invisible, harmless, and overwritten on the
+next attempt, whereas a user document announcing a portal login whose password
+was never stored is a fault the agent discovers at 3am with nothing naming the
+cause.
+
+`storeCredential` encrypts before it writes (contract §6), so a KMS failure gets
+that far and persists nothing at all.
+
+## There is no read path, and there cannot be one
+
+`lib/portalCredentials.ts` used to export `getPortalPassword`. It does not any
+more, and this is not tidying: this application holds `cryptoKeyEncrypter` on
+`classistant-password-key` and nothing else, so a read path here is a function
+the process has no permission to implement. Same shape as the missing
+`unwrapDataKey` in `lib/credentials.ts`. The frontend can lock a password away
+and cannot open it again.
+
+**Nothing can open it yet.** As of this change the key's IAM holds exactly one
+binding, `cryptoKeyEncrypter` for `firebase-app-hosting-compute@`. There is no
+`cryptoKeyDecrypter` on it at all, which is correct for today -- the connector
+must never have one (contract §1) and the agent does not exist. It is also the
+first thing that will need granting when the agent does, and the failure until
+then is a `PermissionDenied` from KMS rather than anything that looks like a
+credential problem.
+
+## What is now stale, and what to do about it
+
+Nothing here deletes anything, deliberately. Two kinds of leftovers exist:
+
+- **Secret Manager secrets** named `user-{uid}-portal-password`, one per student
+  who onboarded before this change. They still bill and are still readable.
+  Destroy them once the students in question have re-onboarded, not before.
+- **Top-level `credentials/{uid}` documents** holding `username` and
+  `secret_name`. Harmless, unread by anything, and worth deleting in the same
+  pass so the collection does not survive as a thing future readers have to work
+  out the status of.
+
+A student who re-onboards writes the new document and does not clean up the old
+pair, because a write path that deletes things is a write path that can delete
+the wrong thing.
+
+## Verifying it
+
+`npm run verify:credentials`, against a running Firestore emulator. It calls the
+real `savePortalCredentials`, reads the document back, and checks the field set
+against §3, the IV length and tag placement against §4, and the absence of the
+plaintext in any encoding.
+
+It uses the **real** KMS, because there is no emulator for it. That is the point
+of the script rather than a limitation of it: the AES layer is already covered
+by `lib/envelope.test.ts` against the connector's own Python, and what this adds
+is proof that the principal can reach the *second* key. That grant is separate
+from the refresh-token key's, was added later, and its absence looks like a
+perfectly working application right up until a student submits step two.
+
+The one thing it cannot check is a round trip, since nothing here may decrypt.
+`lib/credentials.test.ts` covers the gap where it matters most: wrapping a
+password under `classistant-key` by mistake would succeed, write a document that
+passes every other check, and be wrong in exactly one way -- the connector could
+read it.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -23,6 +23,7 @@ Read these before changing something that looks arbitrary. Most of it is not.
 | [14 Attention and nudges](14-attention-and-nudges.md) | The CTA pulse, why the hero gets a different cue, and the 30 second start card |
 | [15 Firebase Auth](15-firebase-auth.md) | Why the login is a phone number, the two ids and the seam between them, the access switches |
 | [16 Onboarding entry cost](16-onboarding-entry-cost.md) | The pause on the first press of Start, why the route could not be prefetched, and the rules that keep it fixed |
+| [19 Portal password envelope](19-portal-password-envelope.md) | Why the password left Secret Manager, which key seals it, where the username went, and what nothing can read yet |
 
 ## Ground rules that apply everywhere
 

--- a/src/frontend/app/onboarding/actions.ts
+++ b/src/frontend/app/onboarding/actions.ts
@@ -9,20 +9,16 @@ import { getSession } from "@/lib/authSession";
 import { FieldValue } from "@/lib/firebaseAdmin";
 import { buildAuthUrl, randomState } from "@/lib/googleOAuth";
 import { setPendingOAuth } from "@/lib/onboardingSession";
-import {
-  getUser,
-  markOnboardingComplete,
-  savePortalCredentials,
-  upsertUser,
-} from "@/lib/users";
+import { savePortalCredentials } from "@/lib/portalCredentials";
+import { getUser, markOnboardingComplete, upsertUser } from "@/lib/users";
 
 /**
  * Onboarding server actions.
  *
  * These are live now. `connectGoogle` starts the scope grant and
- * `completeOnboarding` writes to Firestore and Secret Manager. The pieces sit
- * in four places for a reason (docs/design/12-onboarding-persistence.md and
- * docs/design/15-firebase-auth.md):
+ * `completeOnboarding` writes the profile and seals the portal password. The
+ * pieces sit in four places for a reason (docs/design/12-onboarding-persistence.md
+ * and docs/design/15-firebase-auth.md):
  *
  *   /api/auth/session       Firebase Auth: who the student is
  *   this file               validation, and the two writes onboarding owns
@@ -131,10 +127,10 @@ export async function connectGoogle(
 }
 
 /**
- * Final submit. Writes both onboarding collections.
+ * Final submit. Writes the profile and the portal credential.
  *
- *   users/{uid}        profile + consent evidence
- *   credentials/{uid}  portal username + a Secret Manager pointer
+ *   users/{uid}                              profile, consent evidence, username
+ *   users/{uid}/credentials/school_password  the sealed password
  *
  * Identity comes from the session cookie and the user document, never from the
  * form. The form is client-supplied, and the whole point of the SMS round trip
@@ -193,10 +189,15 @@ export async function completeOnboarding(
   }
 
   // DELIBERATE, DO NOT REMOVE: the portal password is never logged, never
-  // echoed into a response, and never included in an error message. It now goes
-  // straight into Secret Manager via savePortalCredentials() below and nowhere
-  // else -- in particular it is never written to Firestore, because a document
-  // is readable by anything with datastore.user and a secret is not.
+  // echoed into a response, and never included in an error message. It goes
+  // straight into savePortalCredentials() below and nowhere else, and it exists
+  // in this process only long enough to be encrypted.
+  //
+  // It does reach Firestore now, which the previous version of this comment
+  // said it never would. What reaches Firestore is AES-256-GCM ciphertext under
+  // a data key wrapped by `classistant-password-key`, which this app can lock
+  // and cannot open -- so `datastore.user` on the document buys an attacker
+  // nothing. See lib/portalCredentials.ts and docs/design/19.
   //
   // It is stored reversibly, not hashed. The agent has to replay it into the
   // school portal overnight, so hashing is not an option here.
@@ -275,9 +276,9 @@ export async function completeOnboarding(
 
     await markOnboardingComplete(profile.userId);
   } catch (err) {
-    // Never let the error text reach the student: a Firestore or Secret Manager
-    // failure can echo back argument values, and one of the arguments here is a
-    // portal password.
+    // Never let the error text reach the student: a Firestore or KMS failure
+    // can echo back argument values, and one of the arguments here is a portal
+    // password.
     console.error("completeOnboarding failed", {
       userId: profile.userId,
       error: err instanceof Error ? err.message : "unknown",

--- a/src/frontend/app/onboarding/callback/route.ts
+++ b/src/frontend/app/onboarding/callback/route.ts
@@ -22,8 +22,9 @@ import { recordGoogleConnection } from "@/lib/users";
  * connector over server-to-server HTTP, and redirect into the next step.
  *
  * The authorization code passes through this process and is never given to the
- * browser. The refresh token never reaches this process at all -- the connector
- * writes it straight to Secret Manager.
+ * browser. The refresh token does reach this process now that the exchange runs
+ * here, and it lives in memory only long enough to be sealed into Firestore --
+ * see the note on the exchange below.
  *
  * This route no longer mints a session. Identity was settled by Firebase Auth
  * before the grant started, so what arrives here is authorisation for an

--- a/src/frontend/components/onboarding/connectScenes.tsx
+++ b/src/frontend/components/onboarding/connectScenes.tsx
@@ -511,8 +511,9 @@ function IconOutline() {
  * of it. At step one a student types their password into their school's own
  * page and the browser goes there directly, so nothing passes through
  * Classistant and nothing is kept. The phases drawn here are step two's story:
- * the portal password, held in Secret Manager and replayed against the school
- * portal overnight. See docs/design/13-connect-scenes.md.
+ * the portal password, sealed under a Cloud KMS key this app cannot open and
+ * replayed against the school portal overnight. See
+ * docs/design/13-connect-scenes.md.
  */
 
 const CYCLE_B = 28400;
@@ -851,10 +852,13 @@ export function SealedPasswordScene({ school }: { school: School }) {
           On the wording: "government grade" is a marketing phrase, not a
           specification, and this repo's rule is that nothing factual ships
           unverified. The verifiable version of the claim is that the portal
-          password is held in Google Secret Manager, encrypted at rest with
-          AES-256 under Google-managed keys. If this line ever has to be
-          defended, that is the sentence to defend, and "AES-256 encryption" or
-          "Encrypted in Secret Manager" would say it without the puffery. */}
+          password is encrypted with AES-256-GCM under a data key wrapped by a
+          Cloud KMS key that this application can encrypt with and cannot
+          decrypt with. If this line ever has to be defended, that is the
+          sentence to defend, and "AES-256 encryption" would say it without the
+          puffery. The "cannot see" badge on the Classistant machine to the left
+          is the claim that is actually load bearing, and it is now true of the
+          storage as well as the transit. */}
       <g opacity={showEncryption ? 1 : 0} style={{ transition: "opacity 300ms linear" }}>
         <rect
           x="76"

--- a/src/frontend/lib/credentials.test.ts
+++ b/src/frontend/lib/credentials.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { KEY_FOR } from "./credentials";
+
+/**
+ * Which key wraps which credential.
+ *
+ * One assertion, and it is here because this is the only decision in the
+ * envelope that fails silently in both directions. Wrapping a school password
+ * under `classistant-key` succeeds, writes a document that passes every other
+ * check in this suite, and is wrong in exactly one way: the connector can now
+ * read it. Nothing in the write path, the read path, or Firestore would ever
+ * say so. The reverse -- a refresh token under the password key -- at least
+ * announces itself, as a connector that cannot decrypt anything.
+ *
+ * ENCRYPTION_CONTRACT.md §1 and §5. The separation is enforced by the IAM
+ * grants on the two keys; this test is what stops the code from routing around
+ * them by accident.
+ *
+ * Needs `--conditions=react-server`, which the `test` script passes: this
+ * module imports `server-only`, and that package resolves to a throw under any
+ * other condition.
+ */
+
+test("each credential type is wrapped by its own KMS key", () => {
+  assert.equal(KEY_FOR.school_password, "classistant-password-key");
+  assert.equal(KEY_FOR.google_refresh_token, "classistant-key");
+
+  // Not just distinct values -- distinct from each other. A find-and-replace
+  // that pointed both at one key would satisfy neither line above, but a future
+  // third credential type sharing a key would slip past them.
+  const keys = Object.values(KEY_FOR);
+  assert.equal(new Set(keys).size, keys.length, "two credential types share a KMS key");
+});

--- a/src/frontend/lib/credentials.ts
+++ b/src/frontend/lib/credentials.ts
@@ -34,8 +34,13 @@ import { setStampedRef } from "@/lib/users";
  * wrapped under `classistant-password-key` is unreadable to it no matter what
  * bug or compromise it suffers. Sending both through one key would collapse
  * that guarantee into a code review promise.
+ *
+ * Exported so the mapping itself can be asserted. It is the one part of this
+ * file with no observable failure: wrapping a password under the wrong key
+ * succeeds, writes a document that looks perfectly correct, and is only
+ * discovered when the connector turns out to be able to read it.
  */
-const KEY_FOR: Record<CredentialType, string> = {
+export const KEY_FOR: Record<CredentialType, string> = {
   google_refresh_token: "classistant-key",
   school_password: "classistant-password-key",
 };

--- a/src/frontend/lib/portalCredentials.ts
+++ b/src/frontend/lib/portalCredentials.ts
@@ -1,105 +1,63 @@
 import "server-only";
 
-import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
+import { storeCredential } from "@/lib/credentials";
+import { recordSchoolUsername } from "@/lib/users";
 
 /**
- * School portal password storage.
+ * School portal credentials: the one place that knows where each half goes.
  *
  * This is *reversible encryption, not hashing*. The agent has to replay the
- * password into the school's LMS overnight, so a one-way hash is not an option
- * here the way it would be for a password we ourselves authenticate against.
+ * password into the school's LMS overnight, so a one-way hash is not available
+ * to us the way it would be for a password we authenticate against ourselves.
  * That constraint is the whole reason this file exists instead of a bcrypt call.
  *
- * Secret Manager rather than a ciphertext blob in Firestore, for three reasons
- * (docs/design/12):
- *  - it is already how the connector stores per-user refresh tokens (ADR-0002),
- *    so credentials have one storage model and one audit story, not two;
- *  - every individual read is audit logged, which is the only way to ever show
- *    that an unattended agent touched a credential only when it should have;
- *  - no key handling code of our own to get wrong.
+ * It used to write the password to Secret Manager, one secret per student, and
+ * keep a `secret_name` pointer in a top-level `credentials/{uid}` document.
+ * Both are gone. ENCRYPTION_CONTRACT.md §8 retires that path in favour of the
+ * envelope the Google refresh token already uses, and docs/design/19 records
+ * what changed the answer. The short version is that Secret Manager was chosen
+ * when it was the only credential store in the system, and it stopped being
+ * that: two stores meant two audit stories, two failure modes, and a password
+ * whose blast radius was a project-level IAM role rather than a single KMS key
+ * the connector deliberately cannot touch.
  *
- * The trade is cost and sprawl: one secret per user bills per active version per
- * month, which is nothing at current size and a real line item at tens of
- * thousands of students, and there is a per-project secret quota to check before
- * scaling. Envelope encryption under a single Cloud KMS key is flat-cost and is
- * where this should go if that day arrives -- which is why every caller goes
- * through the two functions below and nothing else knows where the bytes live.
+ * The two halves go to different places, and that is the point:
+ *
+ *   password -> users/{uid}/credentials/school_password   sealed, contract §2
+ *   username -> users/{uid}.school_username               a plain identifier
+ *
+ * There is no read path in this file and there cannot be one. This app holds
+ * `cryptoKeyEncrypter` on `classistant-password-key` and nothing else, so
+ * `getPortalPassword` -- which used to sit here and read the secret back -- is
+ * not a function that was removed for tidiness. It is a function this process
+ * has no permission to implement. Reading a school password is the agent's job,
+ * and the agent is the only principal in the project with decrypt on that key
+ * (contract §1). The connector cannot read it either, by the same mechanism.
  */
-
-let client: SecretManagerServiceClient | undefined;
-
-function secrets(): SecretManagerServiceClient {
-  client ??= new SecretManagerServiceClient();
-  return client;
-}
-
-function projectId(): string {
-  const id = process.env.GOOGLE_CLOUD_PROJECT ?? process.env.GCLOUD_PROJECT;
-  if (!id) throw new Error("GOOGLE_CLOUD_PROJECT is not set");
-  return id;
-}
-
-/** Matches the connector's convention in app/services/secrets.py. The Google
- *  `sub` is a stable numeric id, so it is safe in a secret name. */
-function secretId(userId: string): string {
-  return `user-${userId}-portal-password`;
-}
-
-/** The pointer we keep in Firestore. Never the password itself. */
-export function secretName(userId: string): string {
-  return `projects/${projectId()}/secrets/${secretId(userId)}`;
-}
 
 /**
- * Writes the password and returns the resource name to store as a reference.
+ * Seals the password, then records the username.
  *
- * Re-onboarding or a password change adds a new version rather than replacing
- * one, so a student who mistypes and retries does not destroy the working value
- * until the new one is confirmed.
+ * Order matters, and it is the same reasoning as before with the destinations
+ * swapped: the credential goes down first, so a failure between the two leaves
+ * a sealed password nobody is pointing at -- invisible, harmless, and rewritten
+ * on the next attempt -- rather than a user document announcing a portal login
+ * whose password was never stored, which the agent would discover at 3am with
+ * nothing naming the cause.
+ *
+ * `storeCredential` encrypts before it writes (contract §6), so a KMS or crypto
+ * failure gets this far and persists nothing at all.
  */
-export async function storePortalPassword(
-  userId: string,
-  password: string,
-): Promise<string> {
-  const parent = `projects/${projectId()}`;
-  const name = secretName(userId);
-
-  try {
-    await secrets().createSecret({
-      parent,
-      secretId: secretId(userId),
-      secret: { replication: { automatic: {} } },
-    });
-  } catch (err: unknown) {
-    // 6 = ALREADY_EXISTS. Expected on every re-onboard; anything else is real.
-    if ((err as { code?: number }).code !== 6) throw err;
-  }
-
-  await secrets().addSecretVersion({
-    parent: name,
-    payload: { data: Buffer.from(password, "utf8") },
+export async function savePortalCredentials(args: {
+  userId: string;
+  username: string;
+  password: string;
+}): Promise<void> {
+  await storeCredential({
+    uid: args.userId,
+    type: "school_password",
+    plaintext: args.password,
   });
 
-  return name;
-}
-
-/**
- * Reads the current password back. Returns null when nothing is stored, so the
- * caller can send the student through onboarding rather than crash.
- *
- * Nothing in the web app calls this today -- the agent does, and it is here so
- * the read path lives beside the write path and both change together.
- */
-export async function getPortalPassword(userId: string): Promise<string | null> {
-  try {
-    const [version] = await secrets().accessSecretVersion({
-      name: `${secretName(userId)}/versions/latest`,
-    });
-    const data = version.payload?.data;
-    if (!data) return null;
-    return Buffer.from(data as Uint8Array).toString("utf8");
-  } catch (err: unknown) {
-    if ((err as { code?: number }).code === 5) return null; // 5 = NOT_FOUND
-    throw err;
-  }
+  await recordSchoolUsername(args.userId, args.username);
 }

--- a/src/frontend/lib/users.ts
+++ b/src/frontend/lib/users.ts
@@ -1,13 +1,12 @@
 import "server-only";
 
 import { FieldValue, firestore } from "@/lib/firebaseAdmin";
-import { secretName, storePortalPassword } from "@/lib/portalCredentials";
 
 /**
- * The two onboarding collections.
+ * Where a student is written.
  *
- *   users/{uid}        profile + consent evidence
- *   credentials/{uid}  school portal username + a pointer to the password
+ *   users/{uid}                    profile, consent evidence, school identifiers
+ *   users/{uid}/credentials/{type} one sealed credential per type
  *
  * `uid` is the **Firebase Auth uid**, minted by phone sign-in.
  *
@@ -28,9 +27,14 @@ import { secretName, storePortalPassword } from "@/lib/portalCredentials";
  * are addressed by it. It is a field now, not an identity. Anything calling
  * `/users/{user_id}/...` must send `google_sub`, NOT the document id.
  *
- * There is no `password` field on `credentials`, deliberately. The password
- * lives in Secret Manager and the document holds only its resource name -- see
- * lib/portalCredentials.ts for why, and docs/design/12 for what was rejected.
+ * Nothing in this file writes a credential. There used to be a top-level
+ * `credentials/{uid}` document here holding a portal username and a Secret
+ * Manager pointer; ENCRYPTION_CONTRACT.md §8 retired it, and both of a
+ * student's credentials are now sealed documents in the subcollection above.
+ * lib/credentials.ts owns those, and it is the only module that can produce
+ * one. What is left here is the identifiers that are not secret, which is why
+ * `school_username` sits on the user document beside `school_id` and `email`.
+ * See docs/design/19-portal-password-envelope.md.
  */
 
 export type ConsentRecord = {
@@ -231,26 +235,26 @@ export async function recordGoogleConnection(args: {
 }
 
 /**
- * Writes the portal username to Firestore and the password to Secret Manager.
+ * The name the student signs in to their school portal with.
  *
- * Order matters: the secret is written first, so a failure leaves a stored
- * password with no document pointing at it (recoverable, and the name is
- * deterministic) rather than a document promising a credential that does not
- * exist (which the agent would fail on at 3am with no way to tell why).
+ * On the user document rather than in the credential envelope, because it is
+ * not a credential. It is an identifier the school hands out -- often the
+ * student number -- and it belongs with `school_id` and `email`, where anything
+ * holding `datastore.viewer` can read it without being able to open anything.
+ * Sealing it would also put a field in the credential document that
+ * ENCRYPTION_CONTRACT.md §3 does not list, and that document's shape is checked
+ * on the far side.
+ *
+ * Called by savePortalCredentials in lib/portalCredentials.ts, which owns the
+ * order the two halves are written in. Nothing else should call it: a username
+ * with no password behind it is a user document claiming a portal login that
+ * does not exist.
  */
-export async function savePortalCredentials(args: {
-  userId: string;
-  username: string;
-  password: string;
-}): Promise<void> {
-  await storePortalPassword(args.userId, args.password);
-
-  await setStamped("credentials", args.userId, {
-    user_id: args.userId,
-    username: args.username,
-    // A pointer, not a credential. Safe to read, log, and export.
-    secret_name: secretName(args.userId),
-  });
+export async function recordSchoolUsername(
+  userId: string,
+  username: string,
+): Promise<void> {
+  await setStamped("users", userId, { school_username: username });
 }
 
 export async function markOnboardingComplete(userId: string): Promise<void> {

--- a/src/frontend/package-lock.json
+++ b/src/frontend/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@google-cloud/kms": "^5.7.0",
-        "@google-cloud/secret-manager": "^6.3.0",
         "firebase": "^12.18.0",
         "firebase-admin": "^13.10.0",
         "next": "15.5.23",
@@ -1324,18 +1323,6 @@
       "optional": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@google-cloud/secret-manager": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-6.3.0.tgz",
-      "integrity": "sha512-TUuzu8CchbCd2cXd0pYJSXvDBsEVX3wpZu4iOpdLrXLbYbvCDKhdjDyOyC7vo14qQRE9J6Z0AL2hfX08H+fh3A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-gax": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@google-cloud/storage": {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -8,11 +8,11 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "node --import tsx --test lib/*.test.ts"
+    "test": "node --import tsx --conditions=react-server --test lib/*.test.ts",
+    "verify:credentials": "node --import tsx --conditions=react-server scripts/verify-credential-write.mts"
   },
   "dependencies": {
     "@google-cloud/kms": "^5.7.0",
-    "@google-cloud/secret-manager": "^6.3.0",
     "firebase": "^12.18.0",
     "firebase-admin": "^13.10.0",
     "next": "15.5.23",

--- a/src/frontend/scripts/verify-credential-write.mts
+++ b/src/frontend/scripts/verify-credential-write.mts
@@ -1,0 +1,157 @@
+/**
+ * The credential write path, end to end, against real Cloud KMS.
+ *
+ *   FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 GOOGLE_CLOUD_PROJECT=classisstant \
+ *     npm run verify:credentials
+ *
+ * ENCRYPTION_CONTRACT.md §10 asks for one real onboarding run before the demo.
+ * This is the part of that check which does not need a student, a phone, or
+ * Google: it calls the same `savePortalCredentials` the wizard calls, then reads
+ * the document back and checks every byte-level property the contract fixes.
+ *
+ * Firestore is emulated. **KMS is not**, and cannot be -- there is no emulator
+ * for it, so the wrap below is a real encrypt under `classistant-password-key`
+ * with the project's real IAM. That is the point: the AES layer is covered by
+ * lib/envelope.test.ts against the connector's own Python, and the thing this
+ * adds is proof that this principal can actually reach the *second* key. That
+ * grant is separate from the refresh-token key's, was added later, and its
+ * absence looks like a working app right up until a student submits step two.
+ *
+ * Nothing is decrypted here, because this application holds no decrypt role on
+ * either key and never should (contract §1). What can be proven from this side
+ * is the shape, the key identity, and the absence of the plaintext -- which is
+ * every failure mode that does not announce itself.
+ *
+ * Safe to run repeatedly. It writes under a fixed test uid and deletes it.
+ */
+import assert from "node:assert/strict";
+
+import { KeyManagementServiceClient } from "@google-cloud/kms";
+
+import { KEY_FOR } from "@/lib/credentials";
+import { firestore } from "@/lib/firebaseAdmin";
+import { savePortalCredentials } from "@/lib/portalCredentials";
+
+const UID = "verify-credential-write-uid";
+const USERNAME = "s1234567";
+const PASSWORD = "correct horse battery staple ünïcode";
+
+/** Refuses to run against the real database. Every check below writes. */
+if (!process.env.FIRESTORE_EMULATOR_HOST) {
+  console.error(
+    "FIRESTORE_EMULATOR_HOST is not set. This script writes documents, so it " +
+      "will not run against the real project.\n\n" +
+      "  firebase emulators:start   (in another terminal)\n" +
+      "  FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 GOOGLE_CLOUD_PROJECT=classisstant \\\n" +
+      "    npm run verify:credentials",
+  );
+  process.exit(1);
+}
+
+const b64 = (value: string) => Buffer.from(value, "base64");
+const checks: string[] = [];
+const ok = (label: string) => checks.push(`  ok  ${label}`);
+
+const credRef = firestore()
+  .collection("users")
+  .doc(UID)
+  .collection("credentials")
+  .doc("school_password");
+
+// 1 ------------------------------------------------------- the mapping
+assert.equal(KEY_FOR.school_password, "classistant-password-key");
+assert.equal(KEY_FOR.google_refresh_token, "classistant-key");
+ok("school_password maps to classistant-password-key, refresh token to classistant-key");
+
+// 2 ------------------------------ the real write path, emulator + real KMS
+await savePortalCredentials({ userId: UID, username: USERNAME, password: PASSWORD });
+ok("savePortalCredentials() completed against the emulator and real KMS");
+
+const snap = await credRef.get();
+assert.ok(snap.exists, "users/{uid}/credentials/school_password was not written");
+const doc = snap.data()!;
+ok("users/{uid}/credentials/school_password exists");
+
+// 3 ------------------------------------------------ contract §3, the fields
+assert.deepEqual(
+  Object.keys(doc).sort(),
+  [
+    "created_at",
+    "credential_type",
+    "encrypted_credential",
+    "encrypted_dkey",
+    "iv",
+    "updated_at",
+    "user_id",
+  ],
+  "document fields do not match ENCRYPTION_CONTRACT.md §3 exactly",
+);
+assert.equal(doc.user_id, UID);
+assert.equal(doc.credential_type, "school_password");
+ok("fields are exactly the seven §3 names -- no plaintext field, no secret_name");
+
+// 4 -------------------------------------------------- contract §4, the bytes
+assert.equal(b64(doc.iv).length, 12, "iv must be 12 raw bytes");
+assert.equal(
+  b64(doc.encrypted_credential).length,
+  Buffer.byteLength(PASSWORD, "utf8") + 16,
+  "ciphertext must be exactly plaintext length + the 16-byte GCM tag",
+);
+ok("iv is 12 bytes; ciphertext is plaintext+16, so the GCM tag is appended");
+
+assert.ok(!JSON.stringify(doc).includes(PASSWORD), "plaintext password found in the document");
+assert.ok(
+  !b64(doc.encrypted_credential).toString("utf8").includes(PASSWORD),
+  "password recoverable from encrypted_credential without a key",
+);
+ok("the password appears nowhere in the stored document");
+
+// 5 ------------------------------------------------- contract §5, the wrap
+assert.ok(
+  b64(doc.encrypted_dkey).length > 44,
+  "encrypted_dkey is too short to be a KMS wrap -- is the dkey being stored bare?",
+);
+ok(`encrypted_dkey is ${b64(doc.encrypted_dkey).length} bytes of KMS ciphertext`);
+
+// KMS names the key version it used in its response, which is the only way to
+// show from this side which key the wrap actually went through.
+const kms = new KeyManagementServiceClient();
+const [probe] = await kms.encrypt({
+  name: kms.cryptoKeyPath(
+    process.env.GOOGLE_CLOUD_PROJECT!,
+    "us-central1",
+    "classistant-keyring",
+    KEY_FOR.school_password,
+  ),
+  plaintext: Buffer.from("probe", "utf8"),
+  additionalAuthenticatedData: Buffer.from(UID, "utf8"),
+});
+assert.ok(
+  probe.name?.includes("/cryptoKeys/classistant-password-key/cryptoKeyVersions/"),
+  `KMS used an unexpected key: ${probe.name}`,
+);
+ok(`KMS accepted an AAD-bound encrypt on ${probe.name}`);
+
+// 6 --------------------------------------- the username, and where it is not
+const user = await firestore().collection("users").doc(UID).get();
+assert.equal(user.data()?.school_username, USERNAME);
+ok("users/{uid}.school_username holds the portal username");
+
+const retired = await firestore().collection("credentials").doc(UID).get();
+assert.ok(!retired.exists, "the retired top-level credentials/{uid} document was written");
+ok("nothing was written to the retired top-level credentials/{uid}");
+
+// 7 -------------------------- re-onboarding keeps created_at, rotates the IV
+const firstCreated = doc.created_at.toMillis();
+await savePortalCredentials({ userId: UID, username: USERNAME, password: "a different one" });
+const second = (await credRef.get()).data()!;
+assert.equal(second.created_at.toMillis(), firstCreated, "created_at was reset on re-write");
+assert.notEqual(second.iv, doc.iv, "IV was reused across writes -- this breaks GCM");
+ok("a second write keeps created_at and generates a fresh IV");
+
+// ------------------------------------------------------------------ teardown
+await credRef.delete();
+await firestore().collection("users").doc(UID).delete();
+
+console.log(checks.join("\n"));
+console.log("\nall checks passed");

--- a/src/frontend/tsconfig.json
+++ b/src/frontend/tsconfig.json
@@ -31,6 +31,7 @@
   "include": [
     "**/*.ts",
     "**/*.tsx",
+    "**/*.mts",
     ".next/types/**/*.ts",
     "next-env.d.ts",
     ".next-verify/types/**/*.ts"


### PR DESCRIPTION
Stacked on #20, which added the envelope write path but only ever used it for
one of the two credentials. This adds the other one.

`lib/credentials.ts` has mapped `school_password` to `classistant-password-key`
since it was written, and nothing called it. Onboarding was still putting the
password in Secret Manager and leaving a `secret_name` pointer in a top-level
`credentials/{uid}` document, so a student who finished onboarding ended up with
`users/{uid}/credentials/google_refresh_token` and nothing beside it.

`docs/ENCRYPTION_CONTRACT.md` §8 already retired that path. This is the missing
caller.

```
users/{uid}/credentials/school_password
  user_id, credential_type, encrypted_credential, encrypted_dkey, iv,
  created_at, updated_at
```

AES-256-GCM with the tag appended, under a data key wrapped by
`classistant-password-key` in `classistant-keyring`, with the uid as AAD. Byte
for byte the same scheme and the same code path as the refresh token; the only
thing that differs is which key does the wrap.

## Why Secret Manager stopped being the right answer

[Doc 12](docs/design/12-onboarding-persistence.md) weighed the two and picked
Secret Manager for three reasons. Two of them inverted when issue #12 moved
refresh tokens into the envelope as well:

- **"One storage model rather than two."** This was the strongest argument and
  it now runs the other way. Keeping the password behind Secret Manager is what
  creates two storage models.
- **"No key handling code of our own to get wrong."** That code exists, is
  reviewed, and is load bearing for the refresh token. Declining to use it for
  the password buys nothing.
- **"Every individual read is audit logged."** Still true, and a real loss. What
  replaces it is a KMS `Decrypt` log rather than a Firestore one, which is
  arguably the better record because it is the step a reader cannot skip.

What the envelope buys back: the blast radius is one KMS key rather than a
`secretAccessor` role broad enough to match a name prefix, the wrap is bound to
one student by AAD, and cost stops scaling with student count.
[Doc 19](docs/design/19-portal-password-envelope.md) has the whole argument.

## One decision worth a second opinion

The username goes to `users/{uid}.school_username`, not into the credential
document. It is not a credential, it belongs beside `school_id` and `email`, and
putting it in the credential document would add a field §3 does not list and the
connector checks from the other side.

"Where `school_username` lives" is one of the contract's open items, so this is a
decision made here rather than a rule being followed. @MatthewA15 — shout if you
want it somewhere else; the cost to reverse is a field move.

## No read path, and nothing can read it yet

`getPortalPassword` is deleted rather than moved. This app holds
`cryptoKeyEncrypter` on `classistant-password-key` and nothing else, so a read
path here is a function the process has no permission to implement — the same
shape as the missing `unwrapDataKey` in `lib/credentials.ts`.

As of this change the key's IAM holds exactly one binding, `cryptoKeyEncrypter`
for `firebase-app-hosting-compute@`. There is no `cryptoKeyDecrypter` on it at
all, which is correct for today (the connector must never have one, per §1, and
the agent does not exist yet) but is the first grant the agent will need. Until
then the failure is a KMS `PermissionDenied` rather than anything that looks
like a credential problem.

## Leftovers, deliberately not cleaned up

The `user-{uid}-portal-password` secrets and the old top-level
`credentials/{uid}` documents are still there and still billing. Worth destroying
once the affected students have re-onboarded, not before. A write path that
deletes things is a write path that can delete the wrong thing.

## Verifying

`npm run verify:credentials` is new. It calls the real `savePortalCredentials`
against a running Firestore emulator, reads the document back, and checks the
field set against §3, the IV length and tag placement against §4, and the absence
of the plaintext in any encoding.

It uses **real** KMS, because there is no emulator for it. That is the point of
the script rather than a limitation: the AES layer is already covered by
`lib/envelope.test.ts` against the connector's own Python, and what this adds is
proof that the principal can reach the *second* key. That grant is separate from
the refresh-token key's, was added later, and its absence looks like a perfectly
working application right up until a student submits step two.

```
ok  school_password maps to classistant-password-key, refresh token to classistant-key
ok  savePortalCredentials() completed against the emulator and real KMS
ok  users/{uid}/credentials/school_password exists
ok  fields are exactly the seven §3 names -- no plaintext field, no secret_name
ok  iv is 12 bytes; ciphertext is plaintext+16, so the GCM tag is appended
ok  the password appears nowhere in the stored document
ok  encrypted_dkey is 125 bytes of KMS ciphertext
ok  KMS accepted an AAD-bound encrypt on .../classistant-password-key/cryptoKeyVersions/1
ok  users/{uid}.school_username holds the portal username
ok  nothing was written to the retired top-level credentials/{uid}
ok  a second write keeps created_at and generates a fresh IV
```

`lib/credentials.test.ts` covers the gap the script cannot, since nothing here
may decrypt: wrapping a password under `classistant-key` by mistake succeeds,
writes a document that passes every other check, and is wrong in exactly one way,
which is that the connector could read it.

`npm test` 11/11, `npm run typecheck` and `npm run build` clean. Also drops the
now-unused `@google-cloud/secret-manager` dependency and fixes a stale comment in
`callback/route.ts` left over from when the connector ran the exchange.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
