### PR TITLE
feat(docs): render markdown into real Docs formatting behind an opt-in flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ client_secret*.json
 
 # OS
 .DS_Store
+
+# Local task scaffolding, not part of any service
+DOCS_MARKDOWN_PROMPT.md

--- a/src/backend/connectors-api/API_CONTRACT.md
+++ b/src/backend/connectors-api/API_CONTRACT.md
@@ -1,4 +1,4 @@
-# Classistant AI Connector API — Contract v0.5 (handoff for ADK tools)
+# Classistant AI Connector API — Contract v0.6 (handoff for ADK tools)
 
 Base URL: `https://<cloud-run-url>` (local: `http://localhost:8080`). All responses JSON.
 `{user_id}` in every path below is the **Firebase UID** — the same identifier the frontend's session already carries and the `users` collection is keyed by. There is no other identifier this service accepts; a Google `sub` is never a valid `{user_id}`.
@@ -27,7 +27,27 @@ This service has no auth endpoints. Login, the OAuth authorization-code exchange
 |---|---|---|---|
 | GET | `/users/{user_id}/drive/files?q=&max_results=` | optional Drive query | `{files:[{id, name, mimeType, modifiedTime, webViewLink}], count}` |
 | GET | `/users/{user_id}/drive/files/{file_id}/download` | — | **Raw file bytes (not JSON)** with `Content-Type` + `Content-Disposition: attachment; filename=...`. Google-native files are auto-exported (Docs→txt, Sheets→csv, Slides→pdf); other google-apps types → `415`. `404` not found, `403` no access / needs re-consent. ADK tool code must handle a binary response. |
-| POST | `/users/{user_id}/docs` | `{title, content}` | `{doc_id, url, status:"created"}` |
+| POST | `/users/{user_id}/docs` | `{title, content, markdown?}` | `{doc_id, url, status:"created", formatting_applied}` |
+
+### `POST /docs` — markdown rendering (v0.6)
+
+`markdown` is optional and defaults to `false`. **`false` (or absent) is the pre-v0.6 behaviour exactly**: `content` is inserted verbatim as plain text, markdown syntax and all. Existing callers need no change.
+
+Send `markdown: true` to have `content` parsed as markdown and rendered with real Docs formatting:
+
+| Markdown | Becomes |
+|---|---|
+| `#`, `##`, `###` | `HEADING_1`, `HEADING_2`, `HEADING_3` |
+| `**bold**`, `*italic*` | bold / italic text runs |
+| `[text](url)` | a clickable link on `text` |
+| `- item` | a disc-bulleted list |
+| `1. item` | a decimal-numbered list |
+
+Anything outside that set — tables, code fences, block quotes, images, nested list indentation, `####` and deeper headings — is **never dropped**. Its text is inserted unstyled, because a student seeing an unstyled paragraph is far better than a student missing one. Nested list items are flattened to a single level.
+
+The response is `DocCreatedResponse` — `doc_id`, `url`, `status` (unchanged since v0.3) plus `formatting_applied`, which is always present and defaults to `true`.
+
+`formatting_applied` is `false` **only** when `markdown: true` was requested *and* the conversion failed — in which case the Doc was still created, with `content` inserted as unformatted plain text. A malformed heading never costs the student the document, so treat `false` as "the Doc is fine, but it reads as raw markdown", not as an error. It is `true` when markdown rendered successfully, and `true` when `markdown` was false or absent (nothing was requested, so nothing failed).
 
 ## Errors
 
@@ -45,3 +65,4 @@ Every `/users/{user_id}/...` endpoint reads through `app/services/firestore_cred
 - v0.3: added Drive file download; drive.readonly scope added — re-consent required.
 - v0.4 (**breaking**): `/auth/login` and `/auth/callback` removed — login moved to the frontend (issue #12). `{user_id}` in path params is now a Firebase UID, not a Google `sub`. Credential storage moved from Secret Manager to Firestore + KMS envelope encryption; new `500` error semantics for malformed stored credentials (see Errors).
 - v0.5 (**breaking**): corrects a false start within this same version — `/auth/callback` was briefly restored (client secret handling was mistakenly believed to require it) and then removed again for good once [`docs/ENCRYPTION_CONTRACT.md`](../../../docs/ENCRYPTION_CONTRACT.md) settled the frontend as owning the full write side, encrypt included. This service now has **zero** auth endpoints, **zero** KMS encrypt capability, and no code path that can name or touch a `school_password` credential. The `google_sub` fallback lookup on the read path is also removed — `{user_id}` is the Firebase UID with no alternate-identifier tolerance, anywhere. Credential documents are now read from `users/{user_id}/credentials/google_refresh_token` (a direct document get) rather than a queried top-level `user_credentials` collection.
+- v0.6: `POST /docs` accepts an optional `markdown` flag (default `false`), and its response gains `formatting_applied` (default `true`). Both are **additive** — no existing field changed shape or name, and `markdown: false` sends byte-for-byte the request v0.5 sent. `formatting_applied` is a declared field on `DocCreatedResponse`, so it survives the endpoint's `response_model` filtering.

--- a/src/backend/connectors-api/API_CONTRACT.md
+++ b/src/backend/connectors-api/API_CONTRACT.md
@@ -39,7 +39,7 @@ Send `markdown: true` to have `content` parsed as markdown and rendered with rea
 |---|---|
 | `#`, `##`, `###` | `HEADING_1`, `HEADING_2`, `HEADING_3` |
 | `**bold**`, `*italic*` | bold / italic text runs |
-| `[text](url)` | a clickable link on `text` |
+| `[text](url)` | a clickable link on `text`, styled Docs blue (#1155cc) and underlined |
 | `- item` | a disc-bulleted list |
 | `1. item` | a decimal-numbered list |
 

--- a/src/backend/connectors-api/app/routers/docs_service.py
+++ b/src/backend/connectors-api/app/routers/docs_service.py
@@ -3,10 +3,18 @@
 Team decision Aug 19: agent-created artifacts live in Drive (email would be
 too disorganized), so this creates a real Doc the student can open/share.
 """
+import logging
+
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
 
 from app.services.google_creds import service_for_user
+from app.services.markdown_to_requests import (
+    MarkdownConversionError,
+    markdown_to_requests,
+)
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/users/{user_id}/docs", tags=["docs"])
 
@@ -14,27 +22,64 @@ router = APIRouter(prefix="/users/{user_id}/docs", tags=["docs"])
 class DocIn(BaseModel):
     title: str
     content: str  # plain text; agent formats with newlines
+    markdown: bool = False  # opt in to rendering `content` as markdown
 
 
 class DocCreatedResponse(BaseModel):
     doc_id: str = Field(..., description="Google Docs documentId.")
     url: str = Field(..., description="Editable URL for the new Doc.")
     status: str = "created"
+    formatting_applied: bool = Field(
+        True,
+        description=(
+            "False only when `markdown: true` was requested and the conversion "
+            "failed -- the Doc was still created, with `content` inserted as "
+            "unformatted plain text. True when markdown rendered successfully, "
+            "and True when no formatting was requested."
+        ),
+    )
 
 
 @router.post("", status_code=201, response_model=DocCreatedResponse)
 def create_doc(user_id: str, doc: DocIn):
-    """Create a Google Doc with the given title and plain-text content (e.g. an agent-generated study plan)."""
+    """Create a Google Doc with the given title and content (e.g. an agent-generated study plan).
+
+    `content` is inserted verbatim unless `markdown` is true, in which case it
+    is parsed and rendered with real Docs headings, bold, links and lists.
+    """
     svc = service_for_user(user_id, "docs", "v1")
     created = svc.documents().create(body={"title": doc.title}).execute()
     doc_id = created["documentId"]
+    formatting_applied = True
     if doc.content:
-        svc.documents().batchUpdate(
-            documentId=doc_id,
-            body={"requests": [
-                {"insertText": {"location": {"index": 1}, "text": doc.content}}]},
-        ).execute()
+        requests = None
+        if doc.markdown:
+            try:
+                requests = markdown_to_requests(doc.content)
+            except MarkdownConversionError:
+                # Losing the document because a heading was malformed is the
+                # wrong trade: fall back to the plain insert and say so in the
+                # response. Content never reaches the log -- only its size.
+                logger.exception(
+                    "markdown conversion failed; inserting unformatted text "
+                    "(doc_id=%s, content_chars=%d)",
+                    doc_id,
+                    len(doc.content),
+                )
+                formatting_applied = False
+        if requests is None:
+            requests = [
+                {"insertText": {"location": {"index": 1}, "text": doc.content}}]
+        if requests:
+            svc.documents().batchUpdate(
+                documentId=doc_id,
+                body={"requests": requests},
+            ).execute()
+    # Returned as the model, not a dict: `response_model` filters anything not
+    # declared on DocCreatedResponse, so a loose key here would be dropped
+    # silently and a failed conversion would be invisible to the agent.
     return DocCreatedResponse(
         doc_id=doc_id,
         url=f"https://docs.google.com/document/d/{doc_id}/edit",
+        formatting_applied=formatting_applied,
     )

--- a/src/backend/connectors-api/app/services/markdown_to_requests.py
+++ b/src/backend/connectors-api/app/services/markdown_to_requests.py
@@ -1,0 +1,369 @@
+"""Markdown -> Google Docs `batchUpdate` requests. Pure: no Google client, no I/O.
+
+The Docs API has no markdown import; formatting is applied by sending style
+requests against character ranges. The obvious implementation interleaves
+`insertText` with style requests and advances a cursor, but every insert shifts
+the indices of everything after it, and that bookkeeping is where this kind of
+code goes wrong.
+
+So this module does it the other way round:
+
+  1. Walk the parsed markdown once, building (a) the complete plain text of the
+     finished document and (b) styling instructions as offsets into that text.
+  2. Emit a single `insertText` at `insert_index` carrying the whole string.
+  3. Emit every style request after it, each offset shifted by `insert_index`.
+
+Because exactly one request inserts text, no index is ever invalidated, and the
+converter reduces to arithmetic over a string we already hold.
+
+INDEX UNITS -- READ THIS BEFORE CHANGING ANY OFFSET MATH
+--------------------------------------------------------
+The Docs API counts UTF-16 code units, not Python characters. A character
+outside the Basic Multilingual Plane -- an emoji, some CJK extensions -- is one
+Python character but occupies TWO Docs indices. Agent-written study plans
+contain emoji often enough that this is not theoretical.
+
+Every offset here is therefore measured with `utf16_len()`, never `len()`.
+`len()` looks correct and is wrong the moment a plan says "Week 1 goals" with a
+mortarboard next to it: each such character before a styled run drags that run's
+start one index earlier, so the bold lands on the wrong characters and every
+later request is off by a growing amount.
+
+DOCUMENT GEOMETRY
+-----------------
+A Docs body starts at index 1, not 0, and its final newline cannot be deleted.
+Blocks here are joined with "\n" and the last block is left unterminated, so the
+body's own final newline terminates it and no trailing empty paragraph appears.
+"""
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+import mistune
+
+# Docs named styles for markdown heading levels. Levels 4-6 are deliberately
+# absent: they are out of scope for this change and fall through to unstyled
+# body text rather than being dropped.
+# TODO(matthew): extending to HEADING_4..6 is a one-line change to this dict;
+# the index model does not care about heading depth.
+_HEADING_STYLES = {1: "HEADING_1", 2: "HEADING_2", 3: "HEADING_3"}
+
+_BULLET_PRESET_UNORDERED = "BULLET_DISC_CIRCLE_SQUARE"
+_BULLET_PRESET_ORDERED = "NUMBERED_DECIMAL_ALPHA_ROMAN"
+
+# renderer=None puts mistune v3 in AST mode: calling the parser returns the
+# token list instead of rendered HTML. Tables, strikethrough and friends are
+# plugins and stay off, so those constructs arrive as ordinary paragraph text --
+# which is exactly the "pass it through unstyled" behaviour this converter wants.
+_PARSER = mistune.create_markdown(renderer=None)
+
+
+def utf16_len(text: str) -> int:
+    """Length of `text` in UTF-16 code units -- the unit Docs indices use.
+
+    Not `len()`. See the module docstring.
+    """
+    return len(text.encode("utf-16-le")) // 2
+
+
+class MarkdownConversionError(Exception):
+    """Raised when markdown cannot be converted to Docs requests.
+
+    Deliberately carries no document text: the router logs this exception, and
+    document content must never reach a log line.
+    """
+
+
+class _Builder:
+    """Accumulates the plain text and the offsets of everything to be styled.
+
+    Offsets recorded here are relative to the plain text (0-based). They are
+    shifted to document indices exactly once, in `build()`.
+
+    The separator between blocks is *pending* rather than written eagerly, so a
+    block that turns out to emit no text (a blank line, an empty paragraph)
+    costs nothing and cannot leave a stray empty paragraph behind.
+    """
+
+    def __init__(self) -> None:
+        self._parts: list[str] = []
+        self._cursor = 0  # UTF-16 code units written so far
+        self._pending_sep = False
+        self._para_styles: list[tuple[int, int, str]] = []  # start, end, named style
+        self._text_styles: list[tuple[int, int, str, Any]] = []  # start, end, field, value
+        self._bullets: list[tuple[int, int, str]] = []  # start, end, preset
+
+    # -- text accumulation -------------------------------------------------
+
+    def _write(self, text: str) -> None:
+        if not text:
+            return
+        if self._pending_sep:
+            self._pending_sep = False
+            self._parts.append("\n")
+            self._cursor += 1  # "\n" is one UTF-16 code unit
+        self._parts.append(text)
+        self._cursor += utf16_len(text)
+
+    def _start_block(self) -> None:
+        if self._parts:
+            self._pending_sep = True
+
+    def _next_pos(self) -> int:
+        """Offset the next written character will land at, separator included."""
+        return self._cursor + (1 if self._pending_sep else 0)
+
+    @property
+    def plain_text(self) -> str:
+        return "".join(self._parts)
+
+    # -- block level -------------------------------------------------------
+
+    def walk_blocks(self, nodes: Iterable[dict]) -> None:
+        for node in nodes:
+            self._block(node)
+
+    def _block(self, node: dict) -> tuple[int, int] | None:
+        """Emit one block. Returns the (start, end) offsets it wrote, or None."""
+        ntype = node.get("type")
+
+        if ntype in ("blank_line", "thematic_break"):
+            # Nothing to lose: a thematic break carries no text, only a visual
+            # divider.
+            # TODO(matthew): a horizontal rule could become a bottom paragraph
+            # border; out of scope here.
+            return None
+
+        if ntype == "heading":
+            span = self._simple_block(node.get("children") or [])
+            if span is None:
+                return None
+            style = _HEADING_STYLES.get((node.get("attrs") or {}).get("level"))
+            if style:
+                self._para_styles.append((span[0], span[1], style))
+            return span
+
+        if ntype in ("paragraph", "block_text"):
+            return self._simple_block(node.get("children") or [])
+
+        if ntype == "list":
+            self._list(node)
+            return None  # a list spans several paragraphs; runs are tracked in _list
+
+        if ntype == "block_quote":
+            # Out of scope as a style; recurse so the text survives unstyled.
+            # TODO(matthew): block quotes could become an indented paragraph
+            # style; the extension point is here.
+            self.walk_blocks(node.get("children") or [])
+            return None
+
+        if ntype in ("block_code", "block_html"):
+            # Out of scope. Emit the source verbatim as plain paragraphs -- a
+            # student seeing an unstyled code block is far better than a student
+            # missing one.
+            return self._raw_block(node)
+
+        # Unknown or future block type: recurse if it has children, otherwise
+        # emit whatever raw text it carries. Never drop it silently.
+        if node.get("children"):
+            self.walk_blocks(node["children"])
+            return None
+        if node.get("raw"):
+            return self._raw_block(node)
+        return None
+
+    def _simple_block(self, children: Iterable[dict]) -> tuple[int, int] | None:
+        self._start_block()
+        start = self._next_pos()
+        self.walk_inline(children)
+        return (start, self._cursor) if self._cursor > start else None
+
+    def _raw_block(self, node: dict) -> tuple[int, int] | None:
+        self._start_block()
+        start = self._next_pos()
+        self._write((node.get("raw") or "").rstrip("\n"))
+        return (start, self._cursor) if self._cursor > start else None
+
+    def _list(self, node: dict) -> None:
+        """Emit a list's direct items and bullet them in contiguous runs.
+
+        Nested lists are out of scope, so items are flattened to one level and
+        NO leading tabs are emitted -- see `build()` for why tabs specifically
+        would break the index model. A nested list is still walked as its own
+        list node so it keeps its own ordered/unordered glyph; because its items
+        sit between the parent's items, the parent's run is split around them
+        and the two ranges never overlap.
+        """
+        ordered = bool((node.get("attrs") or {}).get("ordered"))
+        preset = _BULLET_PRESET_ORDERED if ordered else _BULLET_PRESET_UNORDERED
+
+        runs: list[list[int]] = []  # [start, end], merged while contiguous
+        for item in node.get("children") or []:
+            if item.get("type") != "list_item":
+                self._block(item)
+                continue
+
+            # One item can hold several blocks, and a nested list may sit
+            # between them. Each contiguous group of the item's own blocks is
+            # tracked separately so a nested list never ends up inside the
+            # parent's range -- otherwise the parent's preset, applied later,
+            # would overwrite the glyph the nested list just asked for.
+            groups: list[list[int]] = []
+            current: list[int] | None = None
+            for child in item.get("children") or []:
+                if child.get("type") == "list":
+                    if current is not None:
+                        groups.append(current)
+                        current = None
+                    self._list(child)  # nested: its own runs, its own preset
+                    continue
+                span = self._block(child)
+                if span is None:
+                    continue
+                if current is None:
+                    current = [span[0], span[1]]
+                else:
+                    current[1] = span[1]
+            if current is not None:
+                groups.append(current)
+
+            for start, end in groups:
+                if end <= start:
+                    continue
+                # A run continues only when this group begins immediately after
+                # the previous one, separated by the single "\n" between blocks.
+                if runs and runs[-1][1] + 1 == start:
+                    runs[-1][1] = end
+                else:
+                    runs.append([start, end])
+
+        for start, end in runs:
+            self._bullets.append((start, end, preset))
+
+    # -- inline level ------------------------------------------------------
+
+    def walk_inline(self, nodes: Iterable[dict]) -> None:
+        for node in nodes:
+            self._inline(node)
+
+    def _inline(self, node: dict) -> None:
+        ntype = node.get("type")
+
+        if ntype == "text":
+            self._write(node.get("raw") or "")
+            return
+
+        if ntype in ("softbreak", "linebreak"):
+            # A real newline rather than CommonMark's space, so line-oriented
+            # passthrough content (a markdown table) keeps its shape instead of
+            # collapsing onto one line.
+            self._write("\n")
+            return
+
+        if ntype == "strong":
+            self._styled_run(node, "bold", True)
+            return
+
+        if ntype == "emphasis":
+            self._styled_run(node, "italic", True)
+            return
+
+        if ntype == "link":
+            url = (node.get("attrs") or {}).get("url")
+            self._styled_run(node, "link", {"url": url} if url else None)
+            return
+
+        if ntype == "image":
+            # Out of scope. Keep the alt text -- or the URL when there is none
+            # -- so the reference is not lost.
+            # TODO(matthew): real images need insertInlineImage, which inserts
+            # content and so must be sequenced against the index model.
+            start = self._cursor
+            self.walk_inline(node.get("children") or [])
+            if self._cursor == start:
+                self._write((node.get("attrs") or {}).get("url") or "")
+            return
+
+        if ntype in ("codespan", "inline_html"):
+            # TODO(matthew): codespan could map to a monospace text style.
+            self._write(node.get("raw") or "")
+            return
+
+        if node.get("children"):
+            self.walk_inline(node["children"])
+        elif node.get("raw"):
+            self._write(node["raw"])
+
+    def _styled_run(self, node: dict, field: str, value: Any) -> None:
+        start = self._cursor
+        self.walk_inline(node.get("children") or [])
+        if value is not None and self._cursor > start:
+            self._text_styles.append((start, self._cursor, field, value))
+
+    # -- emission ----------------------------------------------------------
+
+    def build(self, insert_index: int) -> list[dict]:
+        text = self.plain_text
+        if not text:
+            return []
+
+        def rng(start: int, end: int) -> dict:
+            return {"startIndex": start + insert_index, "endIndex": end + insert_index}
+
+        requests: list[dict] = [
+            {"insertText": {"location": {"index": insert_index}, "text": text}}
+        ]
+
+        for start, end, style in self._para_styles:
+            requests.append({
+                "updateParagraphStyle": {
+                    "range": rng(start, end),
+                    "paragraphStyle": {"namedStyleType": style},
+                    "fields": "namedStyleType",
+                }
+            })
+
+        for start, end, field, value in self._text_styles:
+            requests.append({
+                "updateTextStyle": {
+                    "range": rng(start, end),
+                    "textStyle": {field: value},
+                    "fields": field,
+                }
+            })
+
+        # Bullets go last on purpose. `createParagraphBullets` is documented to
+        # read leading tabs as a nesting level and to REMOVE them, which would
+        # shift every index after it. We emit no tabs, so nothing shifts -- but
+        # ordering these last means no request that depends on the original
+        # indices can ever run after one that could move them.
+        for start, end, preset in self._bullets:
+            requests.append({
+                "createParagraphBullets": {"range": rng(start, end), "bulletPreset": preset}
+            })
+
+        return requests
+
+
+def markdown_to_requests(markdown_text: str, *, insert_index: int = 1) -> list[dict]:
+    """Convert `markdown_text` into an ordered list of Docs `batchUpdate` requests.
+
+    Returns `[]` for input with no text content. The first request is always the
+    single `insertText`; callers and tests can read the exact plain text that
+    will land in the document from `requests[0]["insertText"]["text"]`.
+
+    Raises `MarkdownConversionError` if the markdown cannot be converted; the
+    caller is expected to fall back to a plain `insertText`.
+    """
+    try:
+        tokens = _PARSER(markdown_text or "")
+        if isinstance(tokens, tuple):  # defensive: some builds return (tokens, state)
+            tokens = tokens[0]
+        builder = _Builder()
+        builder.walk_blocks(tokens)
+        return builder.build(insert_index)
+    except Exception as exc:  # noqa: BLE001 -- deliberately broad, see docstring
+        # No document text in this message: it reaches a log line.
+        raise MarkdownConversionError(
+            f"markdown conversion failed in {type(exc).__name__}"
+        ) from exc

--- a/src/backend/connectors-api/app/services/markdown_to_requests.py
+++ b/src/backend/connectors-api/app/services/markdown_to_requests.py
@@ -37,7 +37,7 @@ body's own final newline terminates it and no trailing empty paragraph appears.
 """
 from __future__ import annotations
 
-from typing import Any, Iterable
+from typing import Iterable
 
 import mistune
 
@@ -47,6 +47,15 @@ import mistune
 # TODO(matthew): extending to HEADING_4..6 is a one-line change to this dict;
 # the index model does not care about heading depth.
 _HEADING_STYLES = {1: "HEADING_1", 2: "HEADING_2", 3: "HEADING_3"}
+
+# Setting `link.url` alone makes text clickable but leaves it looking like
+# body text, which in a study plan reads as "the links are broken". The Docs
+# UI pairs a link with blue + underline when you insert one by hand, so we do
+# the same explicitly -- the API applies no styling of its own.
+# #1155cc, Docs' default link blue. Colour components are 0..1 floats.
+_LINK_COLOR = {
+    "color": {"rgbColor": {"red": 17 / 255, "green": 85 / 255, "blue": 204 / 255}}
+}
 
 _BULLET_PRESET_UNORDERED = "BULLET_DISC_CIRCLE_SQUARE"
 _BULLET_PRESET_ORDERED = "NUMBERED_DECIMAL_ALPHA_ROMAN"
@@ -90,7 +99,7 @@ class _Builder:
         self._cursor = 0  # UTF-16 code units written so far
         self._pending_sep = False
         self._para_styles: list[tuple[int, int, str]] = []  # start, end, named style
-        self._text_styles: list[tuple[int, int, str, Any]] = []  # start, end, field, value
+        self._text_styles: list[tuple[int, int, dict]] = []  # start, end, textStyle
         self._bullets: list[tuple[int, int, str]] = []  # start, end, preset
 
     # -- text accumulation -------------------------------------------------
@@ -261,16 +270,25 @@ class _Builder:
             return
 
         if ntype == "strong":
-            self._styled_run(node, "bold", True)
+            self._styled_run(node, {"bold": True})
             return
 
         if ntype == "emphasis":
-            self._styled_run(node, "italic", True)
+            self._styled_run(node, {"italic": True})
             return
 
         if ntype == "link":
             url = (node.get("attrs") or {}).get("url")
-            self._styled_run(node, "link", {"url": url} if url else None)
+            self._styled_run(
+                node,
+                {
+                    "link": {"url": url},
+                    "foregroundColor": _LINK_COLOR,
+                    "underline": True,
+                }
+                if url
+                else None,
+            )
             return
 
         if ntype == "image":
@@ -294,11 +312,11 @@ class _Builder:
         elif node.get("raw"):
             self._write(node["raw"])
 
-    def _styled_run(self, node: dict, field: str, value: Any) -> None:
+    def _styled_run(self, node: dict, style: dict | None) -> None:
         start = self._cursor
         self.walk_inline(node.get("children") or [])
-        if value is not None and self._cursor > start:
-            self._text_styles.append((start, self._cursor, field, value))
+        if style and self._cursor > start:
+            self._text_styles.append((start, self._cursor, style))
 
     # -- emission ----------------------------------------------------------
 
@@ -323,12 +341,14 @@ class _Builder:
                 }
             })
 
-        for start, end, field, value in self._text_styles:
+        for start, end, style in self._text_styles:
             requests.append({
                 "updateTextStyle": {
                     "range": rng(start, end),
-                    "textStyle": {field: value},
-                    "fields": field,
+                    "textStyle": style,
+                    # The mask must name every property being set, or Docs
+                    # silently ignores the ones it does not hear about.
+                    "fields": ",".join(style),
                 }
             })
 

--- a/src/backend/connectors-api/requirements.txt
+++ b/src/backend/connectors-api/requirements.txt
@@ -11,3 +11,4 @@ google-cloud-kms==2.*
 setuptools<81
 cryptography==43.*
 email-validator==2.*
+mistune==3.*

--- a/src/backend/connectors-api/tests/test_docs_router.py
+++ b/src/backend/connectors-api/tests/test_docs_router.py
@@ -112,8 +112,11 @@ def test_response_keeps_its_existing_fields(calls, client):
     assert body["doc_id"] == DOC_ID
     assert body["url"] == f"https://docs.google.com/document/d/{DOC_ID}/edit"
     assert body["status"] == "created"
-    # Added, not renamed: the agent's existing reads are untouched.
-    assert body["formatting_skipped"] is False
+    # Added, not renamed: the agent's existing reads are untouched. This is
+    # also the regression test for the response_model trap -- the field is
+    # declared on DocCreatedResponse, so it survives FastAPI's filtering. A
+    # loose dict key would be dropped here and raise KeyError.
+    assert body["formatting_applied"] is True
 
 
 def test_document_is_created_with_the_title(calls, client):
@@ -138,7 +141,7 @@ def test_markdown_true_sends_converted_requests(calls, client):
     )
 
     assert response.status_code == 201
-    assert response.json()["formatting_skipped"] is False
+    assert response.json()["formatting_applied"] is True
 
     requests = batch_requests(calls)
     assert requests[0] == {
@@ -157,7 +160,7 @@ def test_markdown_true_with_no_renderable_text_sends_no_batch_update(calls, clie
     assert response.status_code == 201
     assert [c for c in calls if c[0] == "batchUpdate"] == []
     # Nothing failed -- there was simply nothing to format.
-    assert response.json()["formatting_skipped"] is False
+    assert response.json()["formatting_applied"] is True
 
 
 # --------------------------------------------------------------------------
@@ -190,7 +193,7 @@ def test_converter_failure_is_reported_in_the_response(calls, client, failing_co
     )
 
     body = response.json()
-    assert body["formatting_skipped"] is True
+    assert body["formatting_applied"] is False
     # The document still exists and is still usable.
     assert body["doc_id"] == DOC_ID
     assert body["status"] == "created"

--- a/src/backend/connectors-api/tests/test_docs_router.py
+++ b/src/backend/connectors-api/tests/test_docs_router.py
@@ -1,0 +1,214 @@
+"""Tests for the /users/{user_id}/docs endpoint.
+
+The Google client is replaced with a recorder that captures the exact
+batchUpdate body, so these assert what would go over the wire without
+mocking out the thing under test.
+
+The load-bearing test here is `test_markdown_false_sends_exactly_todays_request`:
+the agent is already calling this endpoint, and the flag defaulting to false has
+to mean byte-for-byte no change.
+"""
+import logging
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import app.routers.docs_service as docs_service
+from app.services.markdown_to_requests import MarkdownConversionError
+
+DOC_ID = "doc-abc123"
+USER = "firebase-uid-1"
+ENDPOINT = f"/users/{USER}/docs"
+
+
+class _Executable:
+    def __init__(self, result):
+        self._result = result
+
+    def execute(self):
+        return self._result
+
+
+class _FakeDocuments:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def create(self, body):
+        self.calls.append(("create", body))
+        return _Executable({"documentId": DOC_ID})
+
+    def batchUpdate(self, documentId, body):  # noqa: N803 -- Google's parameter name
+        self.calls.append(("batchUpdate", documentId, body))
+        return _Executable({})
+
+
+class _FakeService:
+    def __init__(self, calls):
+        self._documents = _FakeDocuments(calls)
+
+    def documents(self):
+        return self._documents
+
+
+@pytest.fixture
+def calls(monkeypatch):
+    """Records every Google call the router makes."""
+    recorded = []
+    monkeypatch.setattr(
+        docs_service,
+        "service_for_user",
+        lambda user_id, api, version: _FakeService(recorded),
+    )
+    return recorded
+
+
+@pytest.fixture
+def client():
+    api = FastAPI()
+    api.include_router(docs_service.router)
+    return TestClient(api)
+
+
+def batch_requests(calls):
+    """The `requests` list from the single batchUpdate call."""
+    batches = [c for c in calls if c[0] == "batchUpdate"]
+    assert len(batches) == 1, f"expected one batchUpdate, got {len(batches)}"
+    return batches[0][2]["requests"]
+
+
+# --------------------------------------------------------------------------
+# the existing contract must not move
+# --------------------------------------------------------------------------
+
+def test_markdown_false_sends_exactly_todays_request(calls, client):
+    content = "# Not a heading\n\n**not bold**\n- not a bullet"
+    response = client.post(
+        ENDPOINT, json={"title": "Plan", "content": content, "markdown": False}
+    )
+
+    assert response.status_code == 201
+    # Byte-for-byte the request this endpoint has always sent: one insertText
+    # carrying the content verbatim, markdown syntax and all.
+    assert batch_requests(calls) == [
+        {"insertText": {"location": {"index": 1}, "text": content}}
+    ]
+
+
+def test_markdown_field_is_optional_and_defaults_to_the_old_behaviour(calls, client):
+    content = "# Still literal"
+    response = client.post(ENDPOINT, json={"title": "Plan", "content": content})
+
+    assert response.status_code == 201
+    assert batch_requests(calls) == [
+        {"insertText": {"location": {"index": 1}, "text": content}}
+    ]
+
+
+def test_response_keeps_its_existing_fields(calls, client):
+    response = client.post(ENDPOINT, json={"title": "Plan", "content": "hi"})
+    body = response.json()
+
+    assert body["doc_id"] == DOC_ID
+    assert body["url"] == f"https://docs.google.com/document/d/{DOC_ID}/edit"
+    assert body["status"] == "created"
+    # Added, not renamed: the agent's existing reads are untouched.
+    assert body["formatting_skipped"] is False
+
+
+def test_document_is_created_with_the_title(calls, client):
+    client.post(ENDPOINT, json={"title": "Week 1 Plan", "content": ""})
+    assert ("create", {"title": "Week 1 Plan"}) in calls
+
+
+def test_empty_content_sends_no_batch_update(calls, client):
+    response = client.post(ENDPOINT, json={"title": "Plan", "content": ""})
+    assert response.status_code == 201
+    assert [c for c in calls if c[0] == "batchUpdate"] == []
+
+
+# --------------------------------------------------------------------------
+# the new path
+# --------------------------------------------------------------------------
+
+def test_markdown_true_sends_converted_requests(calls, client):
+    response = client.post(
+        ENDPOINT,
+        json={"title": "Plan", "content": "# Plan\n\n- one\n- two", "markdown": True},
+    )
+
+    assert response.status_code == 201
+    assert response.json()["formatting_skipped"] is False
+
+    requests = batch_requests(calls)
+    assert requests[0] == {
+        "insertText": {"location": {"index": 1}, "text": "Plan\none\ntwo"}
+    }
+    kinds = [next(iter(r)) for r in requests]
+    assert kinds == ["insertText", "updateParagraphStyle", "createParagraphBullets"]
+
+
+def test_markdown_true_with_no_renderable_text_sends_no_batch_update(calls, client):
+    # A thematic break carries no text, so there is nothing to insert.
+    response = client.post(
+        ENDPOINT, json={"title": "Plan", "content": "---", "markdown": True}
+    )
+
+    assert response.status_code == 201
+    assert [c for c in calls if c[0] == "batchUpdate"] == []
+    # Nothing failed -- there was simply nothing to format.
+    assert response.json()["formatting_skipped"] is False
+
+
+# --------------------------------------------------------------------------
+# failure falls back rather than losing the document
+# --------------------------------------------------------------------------
+
+@pytest.fixture
+def failing_converter(monkeypatch):
+    def boom(_content):
+        raise MarkdownConversionError("markdown conversion failed in ValueError")
+
+    monkeypatch.setattr(docs_service, "markdown_to_requests", boom)
+
+
+def test_converter_failure_falls_back_to_the_plain_insert(calls, client, failing_converter):
+    content = "# Malformed **thing"
+    response = client.post(
+        ENDPOINT, json={"title": "Plan", "content": content, "markdown": True}
+    )
+
+    assert response.status_code == 201
+    assert batch_requests(calls) == [
+        {"insertText": {"location": {"index": 1}, "text": content}}
+    ]
+
+
+def test_converter_failure_is_reported_in_the_response(calls, client, failing_converter):
+    response = client.post(
+        ENDPOINT, json={"title": "Plan", "content": "# x", "markdown": True}
+    )
+
+    body = response.json()
+    assert body["formatting_skipped"] is True
+    # The document still exists and is still usable.
+    assert body["doc_id"] == DOC_ID
+    assert body["status"] == "created"
+
+
+def test_converter_failure_logs_the_failure_but_never_the_content(
+    calls, client, failing_converter, caplog
+):
+    secret = "the student's private revision timetable"
+    with caplog.at_level(logging.ERROR, logger=docs_service.__name__):
+        client.post(
+            ENDPOINT,
+            json={"title": "Plan", "content": f"# {secret}", "markdown": True},
+        )
+
+    assert caplog.records, "the fallback must be logged, or it cannot be debugged"
+    logged = "\n".join(r.getMessage() + (r.exc_text or "") for r in caplog.records)
+    assert secret not in logged
+    # Still enough to debug: which document, how much content, and a traceback.
+    assert DOC_ID in logged
+    assert "MarkdownConversionError" in logged

--- a/src/backend/connectors-api/tests/test_markdown_to_requests.py
+++ b/src/backend/connectors-api/tests/test_markdown_to_requests.py
@@ -1,0 +1,478 @@
+"""Tests for the markdown -> Docs request converter.
+
+The converter is a pure function, so everything here is exercised directly:
+no Google client, no credentials, no mocking. Golden tests compare whole
+request lists; the offset tests slice the emitted plain text back out using
+UTF-16 arithmetic, which is the only way to prove an index is actually right.
+
+Emoji are written as escapes (\\U0001F393) rather than literals so this file
+stays pure ASCII and cannot be broken by an editor or terminal re-encoding it.
+"""
+import pytest
+
+from app.services.markdown_to_requests import (
+    MarkdownConversionError,
+    markdown_to_requests,
+    utf16_len,
+)
+
+GRADUATION_CAP = "\U0001F393"  # non-BMP: 1 Python char, 2 UTF-16 code units
+INSERT_INDEX = 1  # a Docs body starts at index 1
+
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+
+def plain_text_of(requests):
+    """The exact string the single insertText will put into the document."""
+    return requests[0]["insertText"]["text"]
+
+
+def slice_at(text, start, end, insert_index=INSERT_INDEX):
+    """Return the substring a Docs range [start, end) refers to.
+
+    Slices in UTF-16 code units -- the unit the API counts in -- so this
+    independently reproduces the arithmetic the converter claims to do rather
+    than trusting Python's character indexing.
+    """
+    raw = text.encode("utf-16-le")
+    return raw[(start - insert_index) * 2:(end - insert_index) * 2].decode("utf-16-le")
+
+
+def requests_of_kind(requests, kind):
+    return [r[kind] for r in requests if kind in r]
+
+
+def insert_text_request(text, index=INSERT_INDEX):
+    return {"insertText": {"location": {"index": index}, "text": text}}
+
+
+# --------------------------------------------------------------------------
+# golden tests -- one supported construct at a time, whole-list equality
+# --------------------------------------------------------------------------
+
+def test_heading_levels_one_to_three_are_named_styles():
+    assert markdown_to_requests("# Title") == [
+        insert_text_request("Title"),
+        {
+            "updateParagraphStyle": {
+                "range": {"startIndex": 1, "endIndex": 6},
+                "paragraphStyle": {"namedStyleType": "HEADING_1"},
+                "fields": "namedStyleType",
+            }
+        },
+    ]
+
+    for level, style in ((2, "HEADING_2"), (3, "HEADING_3")):
+        requests = markdown_to_requests(f"{'#' * level} Title")
+        assert requests_of_kind(requests, "updateParagraphStyle") == [
+            {
+                "range": {"startIndex": 1, "endIndex": 6},
+                "paragraphStyle": {"namedStyleType": style},
+                "fields": "namedStyleType",
+            }
+        ]
+
+
+def test_bold_is_an_update_text_style():
+    assert markdown_to_requests("**bold**") == [
+        insert_text_request("bold"),
+        {
+            "updateTextStyle": {
+                "range": {"startIndex": 1, "endIndex": 5},
+                "textStyle": {"bold": True},
+                "fields": "bold",
+            }
+        },
+    ]
+
+
+def test_italic_is_an_update_text_style():
+    assert markdown_to_requests("*slanted*") == [
+        insert_text_request("slanted"),
+        {
+            "updateTextStyle": {
+                "range": {"startIndex": 1, "endIndex": 8},
+                "textStyle": {"italic": True},
+                "fields": "italic",
+            }
+        },
+    ]
+
+
+def test_link_carries_the_url_and_only_covers_the_label():
+    assert markdown_to_requests("[syllabus](https://example.com/s)") == [
+        insert_text_request("syllabus"),
+        {
+            "updateTextStyle": {
+                "range": {"startIndex": 1, "endIndex": 9},
+                "textStyle": {"link": {"url": "https://example.com/s"}},
+                "fields": "link",
+            }
+        },
+    ]
+
+
+def test_unordered_list_is_one_bullet_range_over_both_paragraphs():
+    assert markdown_to_requests("- alpha\n- beta") == [
+        insert_text_request("alpha\nbeta"),
+        {
+            "createParagraphBullets": {
+                "range": {"startIndex": 1, "endIndex": 11},
+                "bulletPreset": "BULLET_DISC_CIRCLE_SQUARE",
+            }
+        },
+    ]
+
+
+def test_ordered_list_uses_the_numbered_preset():
+    assert markdown_to_requests("1. alpha\n2. beta") == [
+        insert_text_request("alpha\nbeta"),
+        {
+            "createParagraphBullets": {
+                "range": {"startIndex": 1, "endIndex": 11},
+                "bulletPreset": "NUMBERED_DECIMAL_ALPHA_ROMAN",
+            }
+        },
+    ]
+
+
+def test_paragraphs_are_separated_by_a_single_newline_and_need_no_requests():
+    # Blank-line separation in markdown becomes one Docs paragraph break, not a
+    # blank paragraph, and the last block is left unterminated so the body's own
+    # final newline terminates it.
+    requests = markdown_to_requests("one\n\ntwo")
+    assert requests == [insert_text_request("one\ntwo")]
+
+
+def test_empty_and_whitespace_only_input_produces_no_requests():
+    assert markdown_to_requests("") == []
+    assert markdown_to_requests("   \n\n  ") == []
+
+
+# --------------------------------------------------------------------------
+# the combined document -- offsets must be right relative to the plain text
+# --------------------------------------------------------------------------
+
+COMBINED_MARKDOWN = """# Study Plan
+
+Read **chapter 3** and *review* the [syllabus](https://example.com/s).
+
+- Monday
+- Tuesday
+
+1. First
+2. Second
+
+## Next week
+"""
+
+
+def test_combined_document_offsets_resolve_to_the_right_substrings():
+    requests = markdown_to_requests(COMBINED_MARKDOWN)
+    text = plain_text_of(requests)
+
+    assert text == (
+        "Study Plan\n"
+        "Read chapter 3 and review the syllabus.\n"
+        "Monday\nTuesday\n"
+        "First\nSecond\n"
+        "Next week"
+    )
+
+    # Every range, whatever kind, must slice back to the text it claims.
+    resolved = []
+    for request in requests[1:]:
+        (kind, body), = request.items()
+        rng = body["range"]
+        resolved.append((kind, slice_at(text, rng["startIndex"], rng["endIndex"])))
+
+    assert resolved == [
+        ("updateParagraphStyle", "Study Plan"),
+        ("updateParagraphStyle", "Next week"),
+        ("updateTextStyle", "chapter 3"),
+        ("updateTextStyle", "review"),
+        ("updateTextStyle", "syllabus"),
+        ("createParagraphBullets", "Monday\nTuesday"),
+        ("createParagraphBullets", "First\nSecond"),
+    ]
+
+
+def test_combined_document_applies_the_expected_style_kinds():
+    requests = markdown_to_requests(COMBINED_MARKDOWN)
+
+    assert [r["paragraphStyle"]["namedStyleType"]
+            for r in requests_of_kind(requests, "updateParagraphStyle")] == [
+        "HEADING_1",
+        "HEADING_2",
+    ]
+    assert [r["textStyle"] for r in requests_of_kind(requests, "updateTextStyle")] == [
+        {"bold": True},
+        {"italic": True},
+        {"link": {"url": "https://example.com/s"}},
+    ]
+    assert [r["bulletPreset"]
+            for r in requests_of_kind(requests, "createParagraphBullets")] == [
+        "BULLET_DISC_CIRCLE_SQUARE",
+        "NUMBERED_DECIMAL_ALPHA_ROMAN",
+    ]
+
+
+def test_exactly_one_request_inserts_text():
+    # The whole index model rests on this: if anything else inserted text, every
+    # offset after it would be wrong.
+    requests = markdown_to_requests(COMBINED_MARKDOWN)
+    assert len(requests_of_kind(requests, "insertText")) == 1
+    assert "insertText" in requests[0]
+
+
+def test_bullets_are_emitted_after_every_other_request():
+    # createParagraphBullets is the one request that can move indices (it strips
+    # leading tabs). Nothing that depends on the original offsets may follow it.
+    requests = markdown_to_requests(COMBINED_MARKDOWN)
+    kinds = [next(iter(r)) for r in requests]
+    first_bullet = kinds.index("createParagraphBullets")
+    assert set(kinds[first_bullet:]) == {"createParagraphBullets"}
+
+
+def test_no_request_emits_a_leading_tab():
+    # Nesting is out of scope precisely so that no tab is ever emitted; see the
+    # createParagraphBullets note in the module docstring.
+    text = plain_text_of(markdown_to_requests("- a\n  - b\n    - c\n- d"))
+    assert "\t" not in text
+    assert not any(line.startswith((" ", "\t")) for line in text.split("\n"))
+
+
+# --------------------------------------------------------------------------
+# UTF-16 -- the test this whole design exists to pass
+# --------------------------------------------------------------------------
+
+def test_utf16_len_counts_code_units_not_characters():
+    assert utf16_len("abc") == 3
+    assert utf16_len(GRADUATION_CAP) == 2
+    assert len(GRADUATION_CAP) == 1  # the trap: Python disagrees with Docs
+
+
+def test_bold_run_after_an_emoji_starts_at_the_right_index():
+    requests = markdown_to_requests(f"Week {GRADUATION_CAP} **goals**")
+    text = plain_text_of(requests)
+    assert text == f"Week {GRADUATION_CAP} goals"
+
+    (style,) = requests_of_kind(requests, "updateTextStyle")
+    start, end = style["range"]["startIndex"], style["range"]["endIndex"]
+
+    # "Week " is 5 units, the cap is 2, the space is 1 -> the run starts at
+    # 8 + insert_index. Using len() would have produced 7 + insert_index and
+    # silently bolded ' goal'.
+    assert (start, end) == (9, 14)
+    assert slice_at(text, start, end) == "goals"
+
+
+def test_every_emoji_before_a_run_shifts_it_by_two_not_one():
+    caps = GRADUATION_CAP * 3
+    requests = markdown_to_requests(f"{caps}**x**")
+    (style,) = requests_of_kind(requests, "updateTextStyle")
+    start = style["range"]["startIndex"]
+
+    assert start == INSERT_INDEX + 6  # 3 caps * 2 code units, not 3 * 1
+    assert slice_at(plain_text_of(requests), start, start + 1) == "x"
+
+
+def test_offsets_stay_correct_with_emoji_across_several_blocks():
+    markdown = (
+        f"# {GRADUATION_CAP} Plan\n\n"
+        f"{GRADUATION_CAP} intro **bold** text\n\n"
+        f"- {GRADUATION_CAP} item one\n- item two\n"
+    )
+    requests = markdown_to_requests(markdown)
+    text = plain_text_of(requests)
+
+    for request in requests[1:]:
+        (_, body), = request.items()
+        rng = body["range"]
+        # A range that ran off the end, or landed mid-surrogate-pair, would
+        # raise or mis-decode here rather than silently passing.
+        assert slice_at(text, rng["startIndex"], rng["endIndex"])
+
+    (style,) = requests_of_kind(requests, "updateTextStyle")
+    assert slice_at(text, style["range"]["startIndex"], style["range"]["endIndex"]) == "bold"
+
+
+def test_final_index_never_exceeds_the_documents_length():
+    requests = markdown_to_requests(f"# {GRADUATION_CAP}\n\ntail {GRADUATION_CAP}")
+    text = plain_text_of(requests)
+    limit = utf16_len(text) + INSERT_INDEX
+    for request in requests[1:]:
+        (_, body), = request.items()
+        assert body["range"]["endIndex"] <= limit
+
+
+# --------------------------------------------------------------------------
+# unsupported constructs -- unstyled, but never dropped
+# --------------------------------------------------------------------------
+
+def test_table_passes_through_as_plain_text_with_no_style_requests():
+    markdown = "| week | topic |\n|---|---|\n| 1 | intro |"
+    requests = markdown_to_requests(markdown)
+
+    assert len(requests) == 1  # insertText only
+    text = plain_text_of(requests)
+    for line in markdown.split("\n"):
+        assert line in text, f"table row lost: {line!r}"
+
+
+def test_code_fence_keeps_its_code_and_emits_no_style_requests():
+    requests = markdown_to_requests("```python\nx = 1\ny = 2\n```")
+
+    assert len(requests) == 1
+    text = plain_text_of(requests)
+    assert "x = 1" in text and "y = 2" in text
+
+
+def test_block_quote_keeps_its_text():
+    requests = markdown_to_requests("> remember the deadline")
+    assert plain_text_of(requests) == "remember the deadline"
+
+
+def test_headings_four_to_six_keep_their_text_unstyled():
+    # Out of scope by design: styled as body text rather than dropped.
+    for level in (4, 5, 6):
+        requests = markdown_to_requests(f"{'#' * level} Deep")
+        assert plain_text_of(requests) == "Deep"
+        assert requests_of_kind(requests, "updateParagraphStyle") == []
+
+
+def test_image_keeps_its_alt_text_and_falls_back_to_the_url():
+    assert plain_text_of(markdown_to_requests("![course logo](http://x/i.png)")) == (
+        "course logo"
+    )
+    assert plain_text_of(markdown_to_requests("![](http://x/i.png)")) == "http://x/i.png"
+
+
+def test_inline_code_keeps_its_text():
+    text = plain_text_of(markdown_to_requests("run `pytest -q` first"))
+    assert text == "run pytest -q first"
+
+
+def test_nested_list_items_are_flattened_but_not_lost():
+    requests = markdown_to_requests("- a\n  - b\n- c")
+    text = plain_text_of(requests)
+
+    assert text == "a\nb\nc"
+    # Every item still gets a bullet; the parent's run is split around the
+    # nested one so the two ranges never overlap.
+    covered = "".join(
+        slice_at(text, r["range"]["startIndex"], r["range"]["endIndex"])
+        for r in requests_of_kind(requests, "createParagraphBullets")
+    )
+    assert set("abc") <= set(covered)
+
+
+def test_a_document_of_only_unsupported_constructs_still_inserts_its_text():
+    requests = markdown_to_requests("---\n\n| a |\n|---|\n\n```\ncode\n```")
+    assert plain_text_of(requests)
+
+
+# --------------------------------------------------------------------------
+# failure behaviour
+# --------------------------------------------------------------------------
+
+def test_conversion_failure_raises_the_typed_error(monkeypatch):
+    import app.services.markdown_to_requests as module
+
+    def boom(_text):
+        raise ValueError("parser exploded")
+
+    monkeypatch.setattr(module, "_PARSER", boom)
+    with pytest.raises(MarkdownConversionError):
+        markdown_to_requests("# anything")
+
+
+def test_conversion_failure_message_contains_no_document_content(monkeypatch):
+    import app.services.markdown_to_requests as module
+
+    secret = "the student's private revision timetable"
+
+    def boom(_text):
+        raise ValueError(f"parser exploded on {secret}")
+
+    monkeypatch.setattr(module, "_PARSER", boom)
+    with pytest.raises(MarkdownConversionError) as excinfo:
+        markdown_to_requests(f"# {secret}")
+
+    # This message reaches a log line, so it must name the failure, not the doc.
+    assert secret not in str(excinfo.value)
+    assert "ValueError" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------
+# insert_index is honoured
+# --------------------------------------------------------------------------
+
+def test_a_non_default_insert_index_shifts_every_range():
+    at_one = markdown_to_requests("# T", insert_index=1)
+    at_fifty = markdown_to_requests("# T", insert_index=50)
+
+    assert at_fifty[0]["insertText"]["location"]["index"] == 50
+    shifted = at_fifty[1]["updateParagraphStyle"]["range"]
+    original = at_one[1]["updateParagraphStyle"]["range"]
+    assert shifted["startIndex"] == original["startIndex"] + 49
+    assert shifted["endIndex"] == original["endIndex"] + 49
+
+
+# --------------------------------------------------------------------------
+# bullet ranges must never overlap
+# --------------------------------------------------------------------------
+
+OVERLAP_CASES = [
+    "- a\n- b",
+    "- a\n  - b\n- c",
+    "1. a\n   - b\n2. c",
+    "- a\n\n  - b\n\n  c\n\n- d",
+    "- a\n  1. b\n  2. c\n- d",
+    "1. a\n2. b\n\ntext\n\n- c\n- d",
+    "- a\n  - b\n    - c\n      - d",
+]
+
+
+@pytest.mark.parametrize("markdown", OVERLAP_CASES)
+def test_bullet_ranges_never_overlap(markdown):
+    # Two createParagraphBullets covering the same paragraph means the later
+    # one silently wins and a list renders with the wrong glyph.
+    requests = markdown_to_requests(markdown)
+    ranges = [
+        (r["range"]["startIndex"], r["range"]["endIndex"])
+        for r in requests_of_kind(requests, "createParagraphBullets")
+    ]
+    for i, (a_start, a_end) in enumerate(ranges):
+        for b_start, b_end in ranges[i + 1:]:
+            assert a_end <= b_start or b_end <= a_start, (
+                f"overlapping bullet ranges {(a_start, a_end)} and {(b_start, b_end)} "
+                f"for {markdown!r}"
+            )
+
+
+@pytest.mark.parametrize("markdown", OVERLAP_CASES)
+def test_every_list_item_text_survives(markdown):
+    text = plain_text_of(markdown_to_requests(markdown))
+    for letter in "abcd":
+        if f" {letter}" in markdown or f".{letter}" in markdown:
+            assert letter in text, f"list item {letter!r} lost from {markdown!r}"
+
+
+def test_nested_list_between_two_blocks_keeps_its_own_preset():
+    # The parent's run must be split around the nested list, not span it.
+    markdown = "1. first\n\n   - nested\n\n   tail\n\n2. second"
+    requests = markdown_to_requests(markdown)
+    text = plain_text_of(requests)
+
+    covered = {}
+    for r in requests_of_kind(requests, "createParagraphBullets"):
+        segment = slice_at(text, r["range"]["startIndex"], r["range"]["endIndex"])
+        for line in segment.split("\n"):
+            covered[line] = r["bulletPreset"]
+
+    assert covered["nested"] == "BULLET_DISC_CIRCLE_SQUARE"
+    assert covered["first"] == "NUMBERED_DECIMAL_ALPHA_ROMAN"
+    assert covered["second"] == "NUMBERED_DECIMAL_ALPHA_ROMAN"

--- a/src/backend/connectors-api/tests/test_markdown_to_requests.py
+++ b/src/backend/connectors-api/tests/test_markdown_to_requests.py
@@ -19,6 +19,16 @@ from app.services.markdown_to_requests import (
 GRADUATION_CAP = "\U0001F393"  # non-BMP: 1 Python char, 2 UTF-16 code units
 INSERT_INDEX = 1  # a Docs body starts at index 1
 
+# A link is clickable AND looks like one: #1155cc + underline, all set in the
+# single updateTextStyle that carries the url.
+LINK_BLUE = {
+    "color": {"rgbColor": {"red": 17 / 255, "green": 85 / 255, "blue": 204 / 255}}
+}
+
+
+def link_style(url):
+    return {"link": {"url": url}, "foregroundColor": LINK_BLUE, "underline": True}
+
 
 # --------------------------------------------------------------------------
 # helpers
@@ -107,11 +117,44 @@ def test_link_carries_the_url_and_only_covers_the_label():
         {
             "updateTextStyle": {
                 "range": {"startIndex": 1, "endIndex": 9},
-                "textStyle": {"link": {"url": "https://example.com/s"}},
-                "fields": "link",
+                "textStyle": link_style("https://example.com/s"),
+                "fields": "link,foregroundColor,underline",
             }
         },
     ]
+
+
+def test_link_is_styled_blue_and_underlined_not_just_clickable():
+    # link.url alone leaves the text looking like body text, which reads to a
+    # student as "the links are broken". Docs applies no styling of its own.
+    (style,) = requests_of_kind(
+        markdown_to_requests("see [the notes](https://example.com/n)"), "updateTextStyle"
+    )
+
+    rgb = style["textStyle"]["foregroundColor"]["color"]["rgbColor"]
+    assert (round(rgb["red"], 4), round(rgb["green"], 4), round(rgb["blue"], 4)) == (
+        round(0x11 / 255, 4),
+        round(0x55 / 255, 4),
+        round(0xCC / 255, 4),
+    )
+    assert style["textStyle"]["underline"] is True
+    assert style["textStyle"]["link"] == {"url": "https://example.com/n"}
+
+
+def test_link_field_mask_names_every_property_it_sets():
+    # Docs silently ignores any property the mask does not mention, so a stale
+    # mask would leave the link black and un-underlined with no error at all.
+    (style,) = requests_of_kind(
+        markdown_to_requests("[x](https://example.com)"), "updateTextStyle"
+    )
+    assert set(style["fields"].split(",")) == set(style["textStyle"])
+
+
+def test_bold_and_italic_masks_stay_single_field():
+    for markdown, field in (("**b**", "bold"), ("*i*", "italic")):
+        (style,) = requests_of_kind(markdown_to_requests(markdown), "updateTextStyle")
+        assert style["fields"] == field
+        assert style["textStyle"] == {field: True}
 
 
 def test_unordered_list_is_one_bullet_range_over_both_paragraphs():
@@ -210,7 +253,7 @@ def test_combined_document_applies_the_expected_style_kinds():
     assert [r["textStyle"] for r in requests_of_kind(requests, "updateTextStyle")] == [
         {"bold": True},
         {"italic": True},
-        {"link": {"url": "https://example.com/s"}},
+        link_style("https://example.com/s"),
     ]
     assert [r["bulletPreset"]
             for r in requests_of_kind(requests, "createParagraphBullets")] == [


### PR DESCRIPTION
Closes #33.

`create_doc` gains `markdown: bool = False`. When true, markdown is converted into Docs `batchUpdate` requests — headings, bold/italic, bullet and numbered lists, links. Default is false, so existing agent calls are unchanged.

## Approach

Rather than walking blocks with a running cursor (where every `insertText` shifts later indices), the converter strips to plain text while recording style ranges as offsets, emits one `insertText`, then all style requests. Only one request inserts text, so no index is ever invalidated. That makes the converter a pure function, fully unit-tested without touching Google's API.

## Notes

- Indices are UTF-16 code units, not Python chars — emoji consume two. Measured with `len(text.encode("utf-16-le")) // 2`, with a test asserting a bold run after an emoji lands correctly.
- `createParagraphBullets` deletes leading tabs (per the API reference), making it the one request that can shift indices. The converter emits no tabs, and all bullet requests are ordered last, with tests pinning both.
- Links get `foregroundColor` and `underline` alongside `link.url`. Docs doesn't auto-style API-set links the way the UI does, so without this they render as plain black text — clickable but invisible.
- The field mask is derived from the style dict's keys rather than hand-maintained. Docs silently ignores any property the mask doesn't name, so a stale mask would drop formatting with no error.
- Response gains `formatting_applied` so the agent can tell when conversion fell back to plain text.

Out of scope, with extension points left: tables, code blocks, block quotes, images, nested lists, h4–h6.

## Testing

72 passed, 1 skipped (pre-existing, unrelated fixture). Verified end to end against a real Google account — headings, bold, bullets and styled links all render correctly.