### PR TITLE
Complete onboarding: name, time_zone, and a schools collection

### DIFF
--- a/docs/design/03-landing-page.md
+++ b/docs/design/03-landing-page.md
@@ -150,5 +150,8 @@ is doing the heaviest lifting on the page: it is the entire reason a student
 would pick this over a to-do app, and it is stated as a fact rather than a
 benefit.
 
-Numbers in copy come from `LIVE_SCHOOLS.length`, never typed. When a school is
-verified and added, the page updates itself.
+Numbers in copy are counted from the live schools, never typed. When a school
+is verified and added, the page updates itself. The count comes from the
+`schools` collection in Firestore now rather than a module constant, so adding a
+campus no longer needs a deploy -- see
+[21 User properties and schools](21-user-properties-and-schools.md).

--- a/docs/design/04-onboarding.md
+++ b/docs/design/04-onboarding.md
@@ -91,11 +91,11 @@ form feel like a lead-capture page.
 
 ## Details step
 
-Name and email are shown as retrieved, not as empty inputs. Two escape hatches:
-**Change nickname** for what the agent calls you, and **Different email for
-Google Drive, Calendar, and email?** for the case where coursework lives in
-another account. Both are collapsed until clicked, so the default path is
-reading two lines and moving on.
+The email is shown as retrieved, not as an empty input. **Name is a required
+field** and always open: it used to be a collapsed "Change nickname" escape
+hatch defaulting to the local part of the address, which was fine while nothing
+read it and became "Hey jokafor3" the moment the agent started greeting people.
+See [21 User properties and schools](21-user-properties-and-schools.md).
 
 While Google is stubbed, the name is placeholder text and the UI says so rather
 than pretending it came from the registrar.

--- a/docs/design/05-schools-data.md
+++ b/docs/design/05-schools-data.md
@@ -1,6 +1,6 @@
 # 05. Schools data
 
-Source: [`scripts/schools.seed.ts`](../../src/frontend/scripts/schools.seed.ts)
+Source: [`data/schools.seed.ts`](../../src/frontend/data/schools.seed.ts)
 
 > **The list moved.** Schools live in the `schools` collection in Firestore now,
 > not in a TypeScript constant. The eligibility rules below are unchanged and
@@ -82,7 +82,7 @@ mail platforms between academic years and they do it quietly. An entry that was
 correct last September is not evidence about this September.
 
 Adding a school is four things now: confirm on the school's IT pages, add the
-entry to `scripts/schools.seed.ts` with its `source`, flip `status` to `live`,
+entry to `data/schools.seed.ts` with its `source`, flip `status` to `live`,
 and run `npm run seed:schools -- --commit`. The landing page count and the
 marquee update themselves once the collection has it.
 

--- a/docs/design/05-schools-data.md
+++ b/docs/design/05-schools-data.md
@@ -1,6 +1,13 @@
 # 05. Schools data
 
-Source: [`data/schools.ts`](../../src/frontend/data/schools.ts)
+Source: [`scripts/schools.seed.ts`](../../src/frontend/scripts/schools.seed.ts)
+
+> **The list moved.** Schools live in the `schools` collection in Firestore now,
+> not in a TypeScript constant. The eligibility rules below are unchanged and
+> still govern which schools may exist at all, but they are enforced against the
+> seed file rather than against the module the app imports. See
+> [21 User properties and schools](21-user-properties-and-schools.md) for what
+> that cost and how seeding works.
 
 ## The eligibility rule
 
@@ -43,8 +50,8 @@ is told plainly that its mail does run on Google and we simply have not opened
 the campus, while a `pending` school gets "Not yet" and the weaker claim. "Soon"
 is a promise, so only a school we have actually confirmed may make it.
 
-`LIVE_SCHOOLS` is what marketing surfaces read from. `SCHOOLS` is what the
-onboarding search reads from. Keep that split.
+`liveSchools(schools)` is what marketing surfaces read from. The whole list is
+what the onboarding search reads from. Keep that split.
 
 ## Current state (August 2026)
 
@@ -74,9 +81,19 @@ produce a student who onboards successfully and then gets nothing.
 mail platforms between academic years and they do it quietly. An entry that was
 correct last September is not evidence about this September.
 
-Adding a school is three things: confirm on the school's IT pages, add the entry
-with its `source`, flip `status` to `live`. The landing page count and the
-marquee update themselves.
+Adding a school is four things now: confirm on the school's IT pages, add the
+entry to `scripts/schools.seed.ts` with its `source`, flip `status` to `live`,
+and run `npm run seed:schools -- --commit`. The landing page count and the
+marquee update themselves once the collection has it.
+
+A school can also be added straight in the Firestore console without a deploy,
+which is the point of the move. Bring it back to the seed file in the same week,
+or the next seed run will report it as an orphan and the one after that will
+have forgotten why it is there.
+
+`LIVE_SCHOOLS` is gone. It was a constant computed at module load, which only
+worked while the list was a literal; `liveSchools(schools)` is the filter now
+and it runs where it is used.
 
 ## The waitlist
 

--- a/docs/design/07-backend-contract.md
+++ b/docs/design/07-backend-contract.md
@@ -42,9 +42,14 @@ cleanly. Put shared constants in a plain module.
 
 ### `completeOnboarding(prev, formData)`
 
-Fields: `schoolId`, `email`, `name`, `nickname`, `serviceEmail` (optional
-alternate Google account), `portalUser`, `portalPassword`, `phone` (digits),
+Fields: `name` (required since #36, no longer defaulted from the address),
+`timeZone` (hidden, the browser's IANA zone), `portalUser`, `portalPassword`,
 `acceptTerms`, `acceptMarketing`, `consentSms` (checkboxes are `"on"` or empty).
+
+The school, the address, and the number are **not** submitted. Each was proven
+by a round trip -- the SMS for the number, the Google exchange for the address
+and school -- and the action reads all three off the session and the user
+document. A form field for any of them would be a second, unproven path.
 
 `portalPassword` is still collected, and deliberately so: OAuth authorises mail,
 calendar, and Drive but gives no session on the school's LMS, and the overnight

--- a/docs/design/12-onboarding-persistence.md
+++ b/docs/design/12-onboarding-persistence.md
@@ -191,10 +191,15 @@ connector endpoint. One id end to end, nothing to join.
 
 The connector requests no `profile` scope and returns no name from
 `/auth/callback`, so nothing in this system ever learns what the registrar calls
-them. `name` is the nickname they chose, falling back to the local part of their
-address, and the UI says so rather than pretending. A real name would cost a
-`profile` scope on both sides plus a new response field on a frozen endpoint,
-for a value nobody currently reads.
+them. `name` is what the student typed when asked.
+
+**Updated by #36.** This used to fall back to the local part of the address when
+they skipped the field, on the reasoning that a real name would cost a `profile`
+scope on both sides "for a value nobody currently reads". Something reads it
+now: the agent greets students by it, and the fallback produced "Hey jokafor3".
+The field is required at onboarding rather than defaulted, and the scope is
+still not worth taking. See
+[21 User properties and schools](21-user-properties-and-schools.md).
 
 ### Consent is not a boolean
 

--- a/docs/design/21-user-properties-and-schools.md
+++ b/docs/design/21-user-properties-and-schools.md
@@ -2,7 +2,7 @@
 
 Sources: [`lib/schools.ts`](../../src/frontend/lib/schools.ts),
 [`lib/timeZone.ts`](../../src/frontend/lib/timeZone.ts),
-[`scripts/schools.seed.ts`](../../src/frontend/scripts/schools.seed.ts)
+[`data/schools.seed.ts`](../../src/frontend/data/schools.seed.ts)
 
 Settles [issue #36](https://github.com/MatthewA15/ClassistantAI/issues/36).
 
@@ -36,24 +36,31 @@ two consents.
 
 ### Why not take it from Google
 
-The issue asked for it, and it was rejected on cost.
+The issue asked for it. It was not taken, and the honest reason is narrower
+than the one first written here.
 
-A real name needs the `profile` scope, and
-[`config.py`](../../src/backend/connectors-api/app/config.py) requires its scope
-list to stay byte-identical to
-[`GOOGLE_SCOPES`](../../src/frontend/lib/googleOAuth.ts). Adding one there
-breaks every grant that already exists: `google-auth` raises on
-`requested - granted`, so the connector would ask for a scope an existing
-refresh token never received and fail on refresh, silently, per student, until
-each of them reconnected.
+**The technical objection turned out not to exist.** An earlier draft of this
+doc argued that a real name needs the `profile` scope, that `config.py` pins a
+scope list which must stay byte-identical to
+[`GOOGLE_SCOPES`](../../src/frontend/lib/googleOAuth.ts), and that widening it
+would break refresh for every existing grant. @obaodelana pointed out on PR #42
+that `config.py` has not carried scopes since `ebfa577`, and checking the code
+it is worse than that for the argument: `firestore_creds.py` builds
+`Credentials(...)` with **no `scopes=` argument at all**, so `self._scopes` is
+`None` and google-auth's `requested - granted` check never runs. Nothing would
+break. The only surviving copy of the list on the Python side is
+`scripts/seed_credential.py`, a dev script.
 
-There is a safe version -- add it to the frontend only, since `exchangeCode`
-never validates the returned scope set and a granted superset refreshes fine --
-but it buys a name the student may not want to be called anyway, at the price of
-inverting an invariant two files state in bold. Asking is one field on a screen
-they are already on. [docs/design/12](12-onboarding-persistence.md) said a real
-registrar name would cost more than it is worth; that is still true, and this is
-the cheaper half of it delivered.
+So what is left is a product judgement, not a constraint:
+
+- The field is editable either way, and a good number of students would change
+  a registrar name to something shorter the first time they saw it.
+- It widens the consent screen for a value one text input already gets.
+
+That is a real reason but a weaker one, and it should be recorded as such. **If
+the agent later wants the legal name specifically -- for a registrar lookup, or
+to match a name on a portal -- adding `profile` to `GOOGLE_SCOPES` is now cheap
+and this decision should be revisited rather than cited.**
 
 ## `time_zone` is top level, and there is exactly one of it
 
@@ -109,7 +116,7 @@ three hours out and a Memorial student three and a half.
 ## The `schools` collection
 
 `data/schools.ts` was a TypeScript constant. It is now `schools/{id}` in
-Firestore, read by `lib/schools.ts` and seeded from `scripts/schools.seed.ts`.
+Firestore, read by `lib/schools.ts` and seeded from `data/schools.seed.ts`.
 
 Two reasons, both from the issue: a school can be added without a deploy, and
 the agent can turn a `school_id` into a name, a city, and a timezone without
@@ -130,13 +137,28 @@ anything useful to a student, and `timeZone` is stored per school rather than
 derived from the province code because **Newfoundland is UTC-3:30** -- any
 two-letter mapping puts every Memorial reminder half an hour out.
 
-### There is no fallback to the seed array, on purpose
+### The seed catalogue is the floor
 
-The obvious safety net is to serve the hardcoded list when Firestore is empty or
-unreachable. That net is a second copy of the data, free to disagree with the
-first, silently, on exactly the day somebody is debugging why a school vanished.
-`listSchools` returns `[]` instead and the picker says it could not load the
-list, which is a visible failure. A wrong list is not.
+When the collection comes back empty or unreadable, `listSchools` serves
+`SEED_SCHOOLS` from `data/schools.seed.ts` rather than an empty list.
+
+The first version refused to, arguing that a second copy of the data can
+silently disagree with the first and that an empty list is at least a *visible*
+failure. @obaodelana rejected that on PR #42, and was right: an empty list is
+not a neutral failure here. The school picker has nothing in it, the Get started
+CTA is gated on a school being picked, and a Firestore hiccup becomes lost
+signups. Stale beats absent when absent means the product does not work.
+
+The disagreement is made loud rather than prevented. Every fallthrough logs an
+error naming which case it hit -- an empty collection tells you to run the
+seeder, a failed read prints the error. Nothing serves the catalogue silently.
+
+This is also what lets `/` stay a prerendered static page. An earlier revision
+called `connection()` in the root layout to opt out of prerendering whenever the
+list came back empty, because a build container has no application default
+credentials and would otherwise have baked a hero with no campus chips into a
+static page for an hour. The fallback removes the condition that guard existed
+for, so the guard is gone.
 
 ### The catch sits outside the cache, and that placement is load-bearing
 
@@ -169,22 +191,18 @@ the browser, and neither can afford that module to reach for a database.
 3. Seed **before** deploying where you can. It is a performance concern now
    rather than a correctness one, for the reason below.
 
-### Why an unseeded build is no longer a broken site
+### Why an unseeded build is not a broken site
 
-It very nearly was. `/` is prerendered and the root layout wraps it, and
-`lib/firebaseAdmin.ts` notes that the *runtime* service account is the one
-holding `datastore.user` -- so a build container without ADC reads nothing and
-would have baked a hero with no campus chips. Not cosmetic: the Get started CTA
-is gated on a school being picked, so a chipless hero has no working path into
-onboarding at all, and ISR would have held it that way for an hour with no way
-to flush it, since the seeder's `revalidateTag` is a no-op from a terminal.
+`/` is prerendered and the root layout wraps it, and `lib/firebaseAdmin.ts`
+notes that the *runtime* service account is the one holding `datastore.user`.
+So a build container without ADC reads nothing -- and bakes the seeded
+catalogue, which is correct enough to start on, rather than an empty hero with
+no path into onboarding.
 
-The root layout calls `connection()` when the list comes back empty, which opts
-that render out of prerendering. An unseeded or unreachable build serves every
-route dynamically and re-reads on the next request instead of freezing a broken
-page. Once a build can see a seeded collection, `/` goes back to static with a
-1h revalidate. The cost is paid only where static generation would have been
-wrong.
+What that costs: a school added in the console is invisible on the static
+landing page until the 1h revalidate turns, and the seeder's `revalidateTag` is
+a no-op from a terminal so there is no way to flush it early. Seeding before a
+deploy avoids the window entirely.
 
 The seeder never deletes. A school in Firestore that is absent from the seed
 file is reported as an orphan and left alone, because the alternative is a
@@ -193,11 +211,13 @@ allow.
 
 ## Still open
 
-- **The rules block is inert.** `firestore.rules` now has a `schools` match with
-  `write: if false`, sitting under a catch-all that grants read and write on
-  everything until 2026-09-21. Firestore grants if *any* rule allows, so a
-  narrower rule cannot take permission back. That wildcard has to go before it
-  expires and locks the project out of its own client SDK.
+- ~~The rules block is inert.~~ **Fixed in this PR**, at @obaodelana's request.
+  The `match /{document=**}` that granted read and write on everything until
+  2026-09-21 is now `if false`, with `schools` open for reading above it. Safe
+  because nothing reads Firestore from a browser: every server reads through the
+  admin SDK, which bypasses rules, and `lib/firebaseClient.ts` loads
+  `firebase/app` and `firebase/auth` only. It also removes an expiry three weeks
+  out that would have failed closed with no warning.
 - **Nothing reads `time_zone` yet.** The agent's prompt carries no student
   context at all, so the frontend now writes three fields the agent side still
   has to pick up. Note that `POST /users/{user_id}/calendar/events` still

--- a/docs/design/21-user-properties-and-schools.md
+++ b/docs/design/21-user-properties-and-schools.md
@@ -1,0 +1,213 @@
+# 21. User properties the agent reads, and the schools collection
+
+Sources: [`lib/schools.ts`](../../src/frontend/lib/schools.ts),
+[`lib/timeZone.ts`](../../src/frontend/lib/timeZone.ts),
+[`scripts/schools.seed.ts`](../../src/frontend/scripts/schools.seed.ts)
+
+Settles [issue #36](https://github.com/MatthewA15/ClassistantAI/issues/36).
+
+## What changed and why now
+
+Until the agent landed, the frontend was the only thing that read a user
+document, and it read it to render a dashboard. Three fields were shaped by
+that: `name` was whatever looked reasonable in a heading, the timezone lived
+wherever the settings form put it, and the school was a `school_id` string that
+only meant something to code holding a copy of `data/schools.ts`.
+
+Then [`webhook.py`](../../src/backend/twilio/functions/webhook.py) started
+looking students up by `phone_number` and handing Agent Engine a `user_id`. The
+agent now greets students, schedules reminders, and knows which campus it is
+talking about, so those three fields stopped being display concerns and became
+a contract with another service.
+
+This doc is what that cost.
+
+## `name` is now asked for, and it is required
+
+It used to be an optional nickname behind a "Change nickname" link, defaulting
+to the local part of the school address. Nothing read it, so a default nobody
+chose was free.
+
+It is not free now. The default produced **"Hey jokafor3"**, which is worse than
+no greeting: it is the product demonstrating, in the first text it ever sends,
+that it does not know who it is talking to. So the field is a real question on
+the summary step, always open, and the Finish button gates on it alongside the
+two consents.
+
+### Why not take it from Google
+
+The issue asked for it, and it was rejected on cost.
+
+A real name needs the `profile` scope, and
+[`config.py`](../../src/backend/connectors-api/app/config.py) requires its scope
+list to stay byte-identical to
+[`GOOGLE_SCOPES`](../../src/frontend/lib/googleOAuth.ts). Adding one there
+breaks every grant that already exists: `google-auth` raises on
+`requested - granted`, so the connector would ask for a scope an existing
+refresh token never received and fail on refresh, silently, per student, until
+each of them reconnected.
+
+There is a safe version -- add it to the frontend only, since `exchangeCode`
+never validates the returned scope set and a granted superset refreshes fine --
+but it buys a name the student may not want to be called anyway, at the price of
+inverting an invariant two files state in bold. Asking is one field on a screen
+they are already on. [docs/design/12](12-onboarding-persistence.md) said a real
+registrar name would cost more than it is worth; that is still true, and this is
+the cheaper half of it delivered.
+
+## `time_zone` is top level, and there is exactly one of it
+
+It already existed as `notifications.timezone`. Two things were wrong with that.
+
+**It was almost never written.** The only writer was the settings form, so the
+field the agent needs in order to schedule anything at all was absent for every
+student who never opened that page, which is most of them. Onboarding captures
+it now, from `Intl.DateTimeFormat().resolvedOptions().timeZone`.
+
+**It was in the wrong place.** A reader that has to reach into a preferences map
+to find out what "9am tomorrow" means will eventually not bother, and then there
+are two timezones on one document. That is a bug with a clock on it: they drift,
+and the half that loses is the one deciding whether 3am counts as quiet hours.
+
+So `time_zone` sits at the top level beside `school_id`, and
+`NotificationPrefs.timezone` is passed in rather than stored.
+`readNotifications` still reads the old `data.timezone` key, but only **below**
+the top-level field. A first pass dropped it outright, reasoning that letting
+the stale copy win would defeat the migration; that reasoning did not survive
+the function's own control flow, which already overwrites the default with the
+top-level value before the fallback is reached. So the top-level field wins
+wherever it exists, and the only documents the old key can decide are the ones
+with no top-level field at all -- which is every account that set a zone before
+this change. Dropping it would have reset all of them to Toronto without anyone
+touching a control, moving a Vancouver student's quiet hours by three hours.
+
+The old key stays until those documents are backfilled. Each account also
+self-heals the first time its owner saves the settings form.
+
+### It is validated, not trusted
+
+It arrives as a hidden input on a server action, which is a public HTTP
+endpoint, and it decides when a student's phone is allowed to ring.
+`resolveTimeZone` asks `Intl` whether the zone resolves rather than matching a
+pattern -- a regex over `Region/City` admits `Foo/Bar` and rejects `UTC`, and
+the question that matters is whether the thing doing arithmetic later can use
+it.
+
+It stores the **canonical** spelling `Intl` resolves to, never the submitted
+string, and that is not tidiness. `Intl` is more forgiving than the consumer:
+it accepts `america/toronto`, `EST5EDT`, and `utc`. The agent is Python, and
+`zoneinfo.ZoneInfo("america/toronto")` raises `ZoneInfoNotFoundError` because
+the tzdata lookup is case sensitive. Returning the input verbatim would have
+stored a value this side called valid and the other side cannot resolve, and it
+would have surfaced as a reminder that never fires, in a different codebase, at
+3am.
+
+The fallback chain is `submitted -> the school's campus zone -> America/Toronto`,
+and the middle link is the useful one. A fixed default would put a UBC student
+three hours out and a Memorial student three and a half.
+
+## The `schools` collection
+
+`data/schools.ts` was a TypeScript constant. It is now `schools/{id}` in
+Firestore, read by `lib/schools.ts` and seeded from `scripts/schools.seed.ts`.
+
+Two reasons, both from the issue: a school can be added without a deploy, and
+the agent can turn a `school_id` into a name, a city, and a timezone without
+carrying its own copy of the list.
+
+### What it cost
+
+Ground rule #4 says nothing factual ships unverified, and the enforcement
+mechanism was that school names lived in a reviewed file. A console-editable
+collection gives that up. The seed file keeps the rules, the source URLs, and
+the August re-verification note, and an edit made in the console should be
+brought back to it in the same week or the next seed run will quietly revert it.
+
+### Two fields were added
+
+`city` and `timeZone`, both for the agent. A province is too coarse to say
+anything useful to a student, and `timeZone` is stored per school rather than
+derived from the province code because **Newfoundland is UTC-3:30** -- any
+two-letter mapping puts every Memorial reminder half an hour out.
+
+### There is no fallback to the seed array, on purpose
+
+The obvious safety net is to serve the hardcoded list when Firestore is empty or
+unreachable. That net is a second copy of the data, free to disagree with the
+first, silently, on exactly the day somebody is debugging why a school vanished.
+`listSchools` returns `[]` instead and the picker says it could not load the
+list, which is a visible failure. A wrong list is not.
+
+### The catch sits outside the cache, and that placement is load-bearing
+
+`listSchools` is called from the root layout, so it is cached for an hour and
+tagged. `readSchools` **throws** on a failed read, and the `try/catch` that
+turns that into `[]` wraps the cached function rather than living inside it.
+
+Catching one level down looks identical and is a deployment hazard:
+`unstable_cache` stores whatever it is handed, so a cold instance that could not
+reach Firestore for one second would bake an empty list in for the next hour and
+take the landing page's campus row and the whole picker with it. A thrown error
+is not cached, so the next request retries.
+
+### One read for the whole app
+
+Five client components need the list -- the picker, the hero, the start nudge,
+the wizard, and the theme provider. The alternative to one context is five prop
+chains through layouts with no interest in schools, so `SchoolThemeProvider`
+carries it: it was already mounted once at the root and already existed to
+answer "which school" for the whole tree. `useSchools()` is the read.
+
+`data/schools.ts` keeps the type and five pure functions that take a list. They
+are pure because onboarding runs them on the server and the hero runs them in
+the browser, and neither can afford that module to reach for a database.
+
+## Deploying this
+
+1. `npm run seed:schools` -- dry run, prints what it would change.
+2. `npm run seed:schools -- --commit` -- writes.
+3. Seed **before** deploying where you can. It is a performance concern now
+   rather than a correctness one, for the reason below.
+
+### Why an unseeded build is no longer a broken site
+
+It very nearly was. `/` is prerendered and the root layout wraps it, and
+`lib/firebaseAdmin.ts` notes that the *runtime* service account is the one
+holding `datastore.user` -- so a build container without ADC reads nothing and
+would have baked a hero with no campus chips. Not cosmetic: the Get started CTA
+is gated on a school being picked, so a chipless hero has no working path into
+onboarding at all, and ISR would have held it that way for an hour with no way
+to flush it, since the seeder's `revalidateTag` is a no-op from a terminal.
+
+The root layout calls `connection()` when the list comes back empty, which opts
+that render out of prerendering. An unseeded or unreachable build serves every
+route dynamically and re-reads on the next request instead of freezing a broken
+page. Once a build can see a seeded collection, `/` goes back to static with a
+1h revalidate. The cost is paid only where static generation would have been
+wrong.
+
+The seeder never deletes. A school in Firestore that is absent from the seed
+file is reported as an orphan and left alone, because the alternative is a
+script that silently reverts the console edits this whole change exists to
+allow.
+
+## Still open
+
+- **The rules block is inert.** `firestore.rules` now has a `schools` match with
+  `write: if false`, sitting under a catch-all that grants read and write on
+  everything until 2026-09-21. Firestore grants if *any* rule allows, so a
+  narrower rule cannot take permission back. That wildcard has to go before it
+  expires and locks the project out of its own client SDK.
+- **Nothing reads `time_zone` yet.** The agent's prompt carries no student
+  context at all, so the frontend now writes three fields the agent side still
+  has to pick up. Note that `POST /users/{user_id}/calendar/events` still
+  defaults `timezone` to `America/Toronto` when the caller omits it
+  (`connectors-api/app/routers/calendar.py`), which is wrong for anyone west of
+  Ontario -- the caller should pass the student's `time_zone`.
+- **Pre-#36 accounts have no top-level `time_zone`.** They read through the
+  compatibility fallback above and fix themselves on the next settings save. A
+  backfill would close it properly.
+- **The dashboard degrades quietly when the catalogue is unreachable.** The
+  settings page distinguishes "Not set" from "Could not load", but the overview,
+  access, and layout surfaces just render without a school name, and the layout
+  loses the school theme.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -27,6 +27,7 @@ Read these before changing something that looks arbitrary. Most of it is not.
 | [18 Emulator env](18-emulator-env.md) | Why the emulator calls Secret Manager, the override file that works and the one that throws, and which three variables belong in it |
 | [19 Portal password envelope](19-portal-password-envelope.md) | Why the password left Secret Manager, which key seals it, where the username went, and what nothing can read yet |
 | [20 The signed-in area](20-dashboard.md) | The four dashboard pages, the second front door at /signin, the two kinds of promise a control can make, and why the task history is empty |
+| [21 User properties and schools](21-user-properties-and-schools.md) | The three fields the agent reads, why the name is asked for rather than taken from Google, and the schools collection |
 
 ## Ground rules that apply everywhere
 

--- a/src/backend/connectors-api/README.md
+++ b/src/backend/connectors-api/README.md
@@ -84,10 +84,22 @@ AAD on the KMS wrap is `utf8_bytes(uid)`, replayed on decrypt
 
 The parent `users/{uid}` document is written by the frontend's
 `src/frontend/lib/users.ts` and carries `email`, `name`, `phone_number`,
-`school_id`, `google_sub`, `service_email`, `google_connected_at`,
+`school_id`, `time_zone`, `google_sub`, `service_email`, `google_connected_at`,
 `onboarding_complete`, `onboarding_completed_at`, `created_at`/`updated_at`,
 plus two maps: `consent` (`terms`/`sms`/`marketing`, each
 `{granted, at, ip, wording}`, kept as CASL and A2P evidence) and `access`.
+
+`name` is what the student typed, not what the registrar calls them: the grant
+requests no `profile` scope. It is required at onboarding rather than defaulted,
+so it is safe to greet somebody with.
+
+`time_zone` is an IANA zone, validated against `Intl` before it is written. It
+is the one to schedule against — note that `POST /users/{user_id}/calendar/events`
+still defaults `timezone` to `America/Toronto` when the caller omits it
+(`app/routers/calendar.py`), which is wrong for anyone west of Ontario. Callers
+should pass the student's `time_zone`. `schools/{school_id}.time_zone` is the
+campus fallback when a user document predates this field. See
+`docs/design/21-user-properties-and-schools.md`.
 
 `access` maps `gmail_read` / `gmail_drafts` / `calendar` / `drive_read` /
 `docs` to booleans — the switches the student actually set. The Google grant is

--- a/src/backend/twilio/firestore.rules
+++ b/src/backend/twilio/firestore.rules
@@ -17,19 +17,28 @@ rules_version='2'
  * and the day somebody does add a client read they will get a permission error
  * rather than silently shipping open access to the `users` collection.
  *
- * ## What this replaced
+ * ## What this replaced, and a correction worth keeping
  *
- * A `match /{document=**}` granting read AND write to anyone until
- * 2026-09-21 -- the default sandbox rule, left in place. That was open access
- * to every student's document: profile, phone number, consent evidence, and the
- * sealed credential subcollection. The envelope encryption in
- * docs/ENCRYPTION_CONTRACT.md meant a reader could not open a password, but
- * everything around it was readable and all of it was writable.
+ * This FILE used to hold the default sandbox rule: `match /{document=**}`
+ * granting read and write to anyone until 2026-09-21. Read literally that is
+ * open access to every student's profile, phone number, and consent evidence,
+ * three weeks from an expiry that fails closed.
  *
- * It was also three weeks from expiring, and expiry fails closed, which would
- * have locked the client SDK out with no warning.
+ * It was never deployed. The live ruleset on `classisstant` as of 2026-08-25
+ * was already `allow read, write: if false` on everything, so production was
+ * locked down the whole time and the file was simply stale. PR #42 originally
+ * reported this the other way round, which was wrong.
  *
- * Requested by @obaodelana on PR #42.
+ * That divergence was the actual hazard: the repo said something far more
+ * permissive than production, so the next person to run
+ * `firebase deploy --only firestore:rules` from a checkout would have opened
+ * the entire database without meaning to. Keeping this file equal to what is
+ * deployed is the point of it existing.
+ *
+ * The only behavioural change from the deployed state is the `schools` block
+ * below, which @obaodelana asked for on PR #42. Nothing in the product needs it
+ * today -- every reader uses the admin SDK -- so it exists for a future
+ * client-side read of what is already public marketing data.
  */
 service cloud.firestore {
   match /databases/{database}/documents {

--- a/src/backend/twilio/firestore.rules
+++ b/src/backend/twilio/firestore.rules
@@ -1,39 +1,65 @@
 rules_version='2'
 
+/*
+ * Deny everything, then open `schools` for reading.
+ *
+ * ## Why a blanket deny is safe here
+ *
+ * Nothing in this product reads Firestore from a browser. The frontend goes
+ * through firebase-admin (src/frontend/lib/firebaseAdmin.ts), the Twilio
+ * functions through firebase_admin (src/backend/twilio/functions/db.py), and
+ * the connector through its own service account. The admin SDK bypasses these
+ * rules entirely, so none of that traffic is affected by anything below.
+ *
+ * The client SDK is loaded for exactly one thing -- phone auth, in
+ * src/frontend/lib/firebaseClient.ts, which imports `firebase/app` and
+ * `firebase/auth` and no Firestore at all. So `if false` costs nothing today,
+ * and the day somebody does add a client read they will get a permission error
+ * rather than silently shipping open access to the `users` collection.
+ *
+ * ## What this replaced
+ *
+ * A `match /{document=**}` granting read AND write to anyone until
+ * 2026-09-21 -- the default sandbox rule, left in place. That was open access
+ * to every student's document: profile, phone number, consent evidence, and the
+ * sealed credential subcollection. The envelope encryption in
+ * docs/ENCRYPTION_CONTRACT.md meant a reader could not open a password, but
+ * everything around it was readable and all of it was writable.
+ *
+ * It was also three weeks from expiring, and expiry fails closed, which would
+ * have locked the client SDK out with no warning.
+ *
+ * Requested by @obaodelana on PR #42.
+ */
 service cloud.firestore {
   match /databases/{database}/documents {
     /*
-     * The school catalogue (issue #36). Reference data about real institutions:
-     * readable by anyone, writable by nobody through a client.
+     * The school catalogue (issue #36). Reference data about real institutions,
+     * already public on the marketing page: readable by anyone, writable by
+     * nobody through a client.
      *
-     * Seeding goes through `npm run seed:schools`, and every read the app makes
-     * is server-side via firebase-admin, which bypasses these rules entirely.
-     * So `write: if false` costs us nothing and closes the console-adjacent
-     * path where a browser could rewrite what a university is called.
-     *
-     * WARNING: this rule is currently INERT. The catch-all below still grants
-     * read and write on every document until 2026-09-21, and Firestore grants
-     * access if ANY matching rule allows it -- a narrower rule cannot take
-     * permission back. This block starts doing something the day that wildcard
-     * is removed, which has to happen before it expires and locks the project
-     * out of its own client SDK.
+     * Seeding runs `npm run seed:schools`, which goes through the admin SDK and
+     * is not governed by this rule.
      */
     match /schools/{schoolId} {
       allow read: if true;
       allow write: if false;
     }
 
+    /*
+     * Everything else, `users` and its credential subcollections above all.
+     *
+     * This has to stay `if false` rather than growing a
+     * `request.auth.uid == uid` allowance. Students authenticate with Firebase
+     * phone auth, so such a rule would look reasonable and would hand every
+     * student direct write access to their own `access` map, `school_id`, and
+     * consent records -- all of which are evidence or enforcement that the
+     * server writes deliberately. The dashboard already edits them through
+     * server actions that check the session cookie. See the rule at the top of
+     * src/frontend/app/dashboard/actions.ts.
+     */
     match /{document=**} {
-      // This rule allows anyone with your database reference to view, edit,
-      // and delete all data in your database. It is useful for getting
-      // started, but it is configured to expire after 30 days because it
-      // leaves your app open to attackers. At that time, all client
-      // requests to your database will be denied.
-      //
-      // Make sure to write security rules for your app before that time, or
-      // else all client requests to your database will be denied until you
-      // update your rules.
-      allow read, write: if request.time < timestamp.date(2026, 9, 21);
+      allow read, write: if false;
     }
   }
 }

--- a/src/backend/twilio/firestore.rules
+++ b/src/backend/twilio/firestore.rules
@@ -2,6 +2,27 @@ rules_version='2'
 
 service cloud.firestore {
   match /databases/{database}/documents {
+    /*
+     * The school catalogue (issue #36). Reference data about real institutions:
+     * readable by anyone, writable by nobody through a client.
+     *
+     * Seeding goes through `npm run seed:schools`, and every read the app makes
+     * is server-side via firebase-admin, which bypasses these rules entirely.
+     * So `write: if false` costs us nothing and closes the console-adjacent
+     * path where a browser could rewrite what a university is called.
+     *
+     * WARNING: this rule is currently INERT. The catch-all below still grants
+     * read and write on every document until 2026-09-21, and Firestore grants
+     * access if ANY matching rule allows it -- a narrower rule cannot take
+     * permission back. This block starts doing something the day that wildcard
+     * is removed, which has to happen before it expires and locks the project
+     * out of its own client SDK.
+     */
+    match /schools/{schoolId} {
+      allow read: if true;
+      allow write: if false;
+    }
+
     match /{document=**} {
       // This rule allows anyone with your database reference to view, edit,
       // and delete all data in your database. It is useful for getting

--- a/src/frontend/app/dashboard/access/page.tsx
+++ b/src/frontend/app/dashboard/access/page.tsx
@@ -10,6 +10,7 @@ import { Badge, Card, CardHead, DataRow } from "@/components/dashboard/ui";
 import { readAccess } from "@/data/access";
 import { getSchool } from "@/data/schools";
 import { getSession } from "@/lib/authSession";
+import { listSchools } from "@/lib/schools";
 import { getAccount, hasPortalPassword } from "@/lib/users";
 
 export const metadata: Metadata = { title: "Access" };
@@ -47,7 +48,9 @@ export default async function AccessPage() {
   if (!account) redirect("/onboarding");
 
   const portalSealed = await hasPortalPassword(session.uid);
-  const school = account.schoolId ? getSchool(account.schoolId) : undefined;
+  const school = account.schoolId
+    ? getSchool(await listSchools(), account.schoolId)
+    : undefined;
 
   return (
     <>

--- a/src/frontend/app/dashboard/actions.ts
+++ b/src/frontend/app/dashboard/actions.ts
@@ -8,14 +8,18 @@ import {
   writeNotifications,
   type NotificationPrefs,
 } from "@/data/notifications";
+import { getSchool } from "@/data/schools";
 import { getSession } from "@/lib/authSession";
 import { savePortalCredentials } from "@/lib/portalCredentials";
+import { listSchools } from "@/lib/schools";
+import { resolveTimeZone } from "@/lib/timeZone";
 import {
   getAccount,
   updateAccessSwitches,
   updateDisplayName,
   updateMarketingPreference,
   updateNotificationPrefs,
+  updateTimeZone,
 } from "@/lib/users";
 
 /**
@@ -31,7 +35,7 @@ import {
  * devtools. `getSession()` returns a uid that Firebase verified, on a cookie
  * this process set and can revoke, and that is the only id any of these use.
  *
- * The same reasoning is why `saveProfile` writes a nickname and nothing else.
+ * The same reasoning is why `saveProfile` writes the name and nothing else.
  * The address was proven by the Google exchange and the number by an SMS round
  * trip; a text input that overwrote either would hand a student an identity
  * nobody checked, which is the whole thing those two round trips exist to
@@ -143,15 +147,30 @@ export async function saveNotifications(
   if (error) return error;
 
   const base = defaultNotifications();
+
+  /*
+   * The zone, resolved against the student's school before any fixed default.
+   *
+   * Read from the browser rather than picked from a list (see the note on
+   * `timezone` in data/notifications.ts), and validated rather than trusted:
+   * `resolveTimeZone` rejects anything `Intl` will not recognise, because this
+   * is a hidden input on a public endpoint and it decides what "10 PM" means.
+   *
+   * It is stored at the top level of the document, not in the prefs map. That
+   * is the whole point of #36: one field, where the agent can find it.
+   */
+  const account = await getAccount(uid);
+  const school = account?.schoolId
+    ? getSchool(await listSchools(), account.schoolId)
+    : undefined;
+  const timeZone = resolveTimeZone(formData.get("timeZone"), school?.timeZone);
+
   const prefs: NotificationPrefs = {
     quietStart: readHour(formData.get("quietStart"), base.quietStart),
     quietEnd: readHour(formData.get("quietEnd"), base.quietEnd),
     calls: formData.get("calls") === "on",
     digestHour: readHour(formData.get("digestHour"), null),
-    // Read from the browser rather than picked from a list. See the note on
-    // `timezone` in data/notifications.ts for why it is not inferred from the
-    // phone number.
-    timezone: String(formData.get("timezone") ?? "").trim() || base.timezone,
+    timezone: timeZone,
   };
 
   /*
@@ -169,6 +188,7 @@ export async function saveNotifications(
 
   try {
     await updateNotificationPrefs(uid, writeNotifications(prefs));
+    await updateTimeZone(uid, timeZone);
     await updateMarketingPreference(uid, formData.get("marketing") === "on");
   } catch (err) {
     console.error("saveNotifications failed", {
@@ -182,8 +202,8 @@ export async function saveNotifications(
   return { ok: true, message: "Saved." };
 }
 
-/** The nickname, and only the nickname. See the rule at the top of this file
- *  for why the address and the number are not here. */
+/** The name, and only the name. See the rule at the top of this file for why
+ *  the address and the number are not here. */
 export async function saveProfile(
   _prev: SaveResult | null,
   formData: FormData,
@@ -191,19 +211,19 @@ export async function saveProfile(
   const { uid, error } = await requireUid();
   if (error) return error;
 
-  const name = String(formData.get("nickname") ?? "").trim();
+  const name = String(formData.get("name") ?? "").trim();
   if (name.length < 1) {
     return {
       ok: false,
       message: "Give it something to call you.",
-      errors: { nickname: "This cannot be empty." },
+      errors: { name: "This cannot be empty." },
     };
   }
   if (name.length > 40) {
     return {
       ok: false,
       message: "That name is too long.",
-      errors: { nickname: "Keep it under 40 characters." },
+      errors: { name: "Keep it under 40 characters." },
     };
   }
 

--- a/src/frontend/app/dashboard/activity/page.tsx
+++ b/src/frontend/app/dashboard/activity/page.tsx
@@ -38,7 +38,7 @@ export default async function ActivityPage() {
     getActivity(session.uid),
   ]);
 
-  const prefs = readNotifications(account?.notifications);
+  const prefs = readNotifications(account?.notifications, account?.timeZone);
 
   return (
     <>

--- a/src/frontend/app/dashboard/layout.tsx
+++ b/src/frontend/app/dashboard/layout.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { DashboardFrame } from "@/components/dashboard/chrome";
 import { getSchool } from "@/data/schools";
 import { getSession } from "@/lib/authSession";
+import { listSchools } from "@/lib/schools";
 import { getUser } from "@/lib/users";
 
 export const metadata: Metadata = {
@@ -62,7 +63,7 @@ export default async function DashboardLayout({
 
   return (
     <DashboardFrame
-      school={record.schoolId ? (getSchool(record.schoolId) ?? null) : null}
+      school={record.schoolId ? (getSchool(await listSchools(), record.schoolId) ?? null) : null}
       phone={session.phone}
     >
       {children}

--- a/src/frontend/app/dashboard/page.tsx
+++ b/src/frontend/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { ACCESS_ITEMS, readAccess } from "@/data/access";
 import { readNotifications } from "@/data/notifications";
 import { getSchool } from "@/data/schools";
 import { getActivity } from "@/lib/activity";
+import { listSchools } from "@/lib/schools";
 import { getSession } from "@/lib/authSession";
 import { getAccount, hasPortalPassword } from "@/lib/users";
 
@@ -50,10 +51,12 @@ export default async function OverviewPage() {
     getActivity(session.uid, PREVIEW),
   ]);
 
-  const school = account.schoolId ? getSchool(account.schoolId) : undefined;
+  const school = account.schoolId
+    ? getSchool(await listSchools(), account.schoolId)
+    : undefined;
   const access = readAccess(account.access);
   const on = ACCESS_ITEMS.filter((item) => access[item.key]);
-  const prefs = readNotifications(account.notifications);
+  const prefs = readNotifications(account.notifications, account.timeZone);
   const firstName = (account.name ?? "").split(" ")[0];
 
   return (

--- a/src/frontend/app/dashboard/settings/page.tsx
+++ b/src/frontend/app/dashboard/settings/page.tsx
@@ -92,19 +92,20 @@ export default async function SettingsPage() {
             />
             {/*
               Three states, not two. `school` is undefined both when the student
-              has no school and when the catalogue could not be read, and
-              collapsing those told a fully onboarded student "Not set" about a
-              school sitting on their own document. `schoolId` is what says
-              which of the two it is.
+              has no school and when their `school_id` is not in the catalogue,
+              and collapsing those told a fully onboarded student "Not set"
+              about a school sitting on their own document. `schoolId` is what
+              says which of the two it is. The second case now means a school
+              was removed or renamed, not that the list failed to load.
             */}
             <DataRow
               label="School"
-              value={school?.name ?? (account.schoolId ? "Could not load" : "Not set")}
+              value={school?.name ?? (account.schoolId ? "Unrecognised" : "Not set")}
               hint={
                 school
                   ? `Taken from your @${school.emailDomain} address, so it follows the account rather than being picked.`
                   : account.schoolId
-                    ? "We could not reach the school list just now. Your account is unaffected."
+                    ? `Your account says ${account.schoolId}, which is not in the school list. Your account is unaffected; tell us and we will fix the list.`
                     : undefined
               }
             />

--- a/src/frontend/app/dashboard/settings/page.tsx
+++ b/src/frontend/app/dashboard/settings/page.tsx
@@ -10,6 +10,7 @@ import { Card, CardHead, DataRow, buttonClass } from "@/components/dashboard/ui"
 import { readNotifications } from "@/data/notifications";
 import { getSchool } from "@/data/schools";
 import { getSession } from "@/lib/authSession";
+import { listSchools } from "@/lib/schools";
 import { getAccount } from "@/lib/users";
 
 export const metadata: Metadata = { title: "Settings" };
@@ -45,8 +46,10 @@ export default async function SettingsPage() {
   const account = await getAccount(session.uid);
   if (!account) redirect("/onboarding");
 
-  const school = account.schoolId ? getSchool(account.schoolId) : undefined;
-  const prefs = readNotifications(account.notifications);
+  const school = account.schoolId
+    ? getSchool(await listSchools(), account.schoolId)
+    : undefined;
+  const prefs = readNotifications(account.notifications, account.timeZone);
 
   return (
     <>
@@ -60,7 +63,13 @@ export default async function SettingsPage() {
           <CardHead title="You" />
 
           <div className="border-b border-line-soft pb-4">
-            <ProfileForm name={account.name ?? account.email?.split("@")[0] ?? "you"} />
+            {/* No address-derived fallback. It used to read
+                `account.name ?? account.email?.split("@")[0]`, which put
+                `jokafor3` into the input as a real editable value -- so a
+                student pressing Change and then Save committed the exact string
+                #36 made this field required to avoid. An account with no name
+                predates that requirement; the field opens empty and asks. */}
+            <ProfileForm name={account.name} />
           </div>
 
           <dl className="pt-1">
@@ -81,13 +90,22 @@ export default async function SettingsPage() {
                 </Link>
               }
             />
+            {/*
+              Three states, not two. `school` is undefined both when the student
+              has no school and when the catalogue could not be read, and
+              collapsing those told a fully onboarded student "Not set" about a
+              school sitting on their own document. `schoolId` is what says
+              which of the two it is.
+            */}
             <DataRow
               label="School"
-              value={school?.name ?? "Not set"}
+              value={school?.name ?? (account.schoolId ? "Could not load" : "Not set")}
               hint={
                 school
                   ? `Taken from your @${school.emailDomain} address, so it follows the account rather than being picked.`
-                  : undefined
+                  : account.schoolId
+                    ? "We could not reach the school list just now. Your account is unaffected."
+                    : undefined
               }
             />
             <DataRow

--- a/src/frontend/app/layout.tsx
+++ b/src/frontend/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata, Viewport } from "next";
 import { Bricolage_Grotesque, Hanken_Grotesk } from "next/font/google";
-import { connection } from "next/server";
 import { SchoolThemeProvider } from "@/components/theme/SchoolTheme";
 import { listSchools } from "@/lib/schools";
 import "./globals.css";
@@ -57,26 +56,21 @@ export const viewport: Viewport = {
  * to every client component through one context instead of five prop chains.
  */
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
-  const schools = await listSchools();
-
   /*
-   * An empty list must never be baked into a static page.
-   *
-   * `/` is prerendered, and this layout wraps it. A build container without
-   * application default credentials -- which is the normal case, since
+   * Never empty. `listSchools` serves the seeded catalogue when Firestore gives
+   * it nothing, which is what lets `/` stay a prerendered static page: a build
+   * container without application default credentials -- the normal case, since
    * lib/firebaseAdmin.ts notes it is the *runtime* service account that holds
-   * `datastore.user` -- reads nothing, and the hero would ship with no campus
-   * chips. That is not cosmetic: the Get started CTA is gated on a school being
-   * picked, so a chipless hero has no working path into onboarding at all, and
-   * ISR would hold it that way for an hour with no way to flush it (the
-   * seeder's `revalidateTag` is a no-op from a terminal).
+   * `datastore.user` -- bakes the seeded list rather than an empty hero.
    *
-   * `connection()` opts this render out of prerendering, so the page is served
-   * dynamically instead and the very next request re-reads. It costs static
-   * generation only in the case where static generation would have been wrong,
-   * and it un-costs it as soon as a build can see a seeded collection.
+   * That distinction is load-bearing. The Get started CTA is gated on a school
+   * being picked, so a hero with no campus chips has no working path into
+   * onboarding at all, and ISR would have held it that way for an hour with no
+   * way to flush it. An earlier revision solved that by calling `connection()`
+   * to opt out of prerendering whenever the list came back empty; the fallback
+   * removes the condition that guard existed for, so it is gone.
    */
-  if (schools.length === 0) await connection();
+  const schools = await listSchools();
 
   return (
     <html lang="en-CA" className={`${bodyFace.variable} ${displayFace.variable}`}>

--- a/src/frontend/app/layout.tsx
+++ b/src/frontend/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata, Viewport } from "next";
 import { Bricolage_Grotesque, Hanken_Grotesk } from "next/font/google";
+import { connection } from "next/server";
 import { SchoolThemeProvider } from "@/components/theme/SchoolTheme";
+import { listSchools } from "@/lib/schools";
 import "./globals.css";
 
 /**
@@ -45,11 +47,41 @@ export const viewport: Viewport = {
   themeColor: "#06203a",
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+/**
+ * Async, because the school list is read here and nowhere else.
+ *
+ * One read for the whole app. `listSchools` is cached for an hour and tagged
+ * (lib/schools.ts), so the legal pages and the dashboard do not each pay a
+ * Firestore round trip for a list only the hero and the wizard actually use.
+ * Reading it here rather than per route is what lets the provider below hand it
+ * to every client component through one context instead of five prop chains.
+ */
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const schools = await listSchools();
+
+  /*
+   * An empty list must never be baked into a static page.
+   *
+   * `/` is prerendered, and this layout wraps it. A build container without
+   * application default credentials -- which is the normal case, since
+   * lib/firebaseAdmin.ts notes it is the *runtime* service account that holds
+   * `datastore.user` -- reads nothing, and the hero would ship with no campus
+   * chips. That is not cosmetic: the Get started CTA is gated on a school being
+   * picked, so a chipless hero has no working path into onboarding at all, and
+   * ISR would hold it that way for an hour with no way to flush it (the
+   * seeder's `revalidateTag` is a no-op from a terminal).
+   *
+   * `connection()` opts this render out of prerendering, so the page is served
+   * dynamically instead and the very next request re-reads. It costs static
+   * generation only in the case where static generation would have been wrong,
+   * and it un-costs it as soon as a build can see a seeded collection.
+   */
+  if (schools.length === 0) await connection();
+
   return (
     <html lang="en-CA" className={`${bodyFace.variable} ${displayFace.variable}`}>
       <body className="bg-white antialiased">
-        <SchoolThemeProvider>
+        <SchoolThemeProvider schools={schools}>
           <a
             href="#main"
             className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:rounded-lg focus:bg-ink-900 focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-white"

--- a/src/frontend/app/onboarding/actions.ts
+++ b/src/frontend/app/onboarding/actions.ts
@@ -10,6 +10,8 @@ import { FieldValue } from "@/lib/firebaseAdmin";
 import { buildAuthUrl, randomState } from "@/lib/googleOAuth";
 import { setPendingOAuth } from "@/lib/onboardingSession";
 import { savePortalCredentials } from "@/lib/portalCredentials";
+import { listSchools } from "@/lib/schools";
+import { resolveTimeZone } from "@/lib/timeZone";
 import { getUser, markOnboardingComplete, upsertUser } from "@/lib/users";
 
 /**
@@ -34,11 +36,12 @@ export type ActionResult = {
   errors?: Record<string, string>;
 };
 
+/** What the grant proved about the student. The address and nothing else: the
+ *  grant requests no `profile` scope, so Google returns no name, and the one
+ *  this type used to carry was the local part of the address wearing a label
+ *  that said otherwise. The student is asked for their name now. */
 export type Identity = {
   email: string;
-  /** Derived from the address, not from Google. The connector requests no
-   *  `profile` scope, so no real name is ever returned. */
-  name: string;
 };
 
 /*
@@ -90,7 +93,7 @@ export async function connectGoogle(
     return { ok: false, message: "Verify your mobile number first." };
   }
 
-  const school = getSchool(schoolId);
+  const school = getSchool(await listSchools(), schoolId);
   if (!school || school.status !== "live") {
     return { ok: false, message: "Pick a supported school first." };
   }
@@ -169,7 +172,7 @@ export async function completeOnboarding(
     };
   }
 
-  const school = getSchool(profile.schoolId ?? "");
+  const school = getSchool(await listSchools(), profile.schoolId ?? "");
   if (!school || school.status !== "live") errors.schoolId = "Choose a supported school.";
 
   const email = profile.email;
@@ -177,8 +180,34 @@ export async function completeOnboarding(
     errors.email = `That is not an @${school.emailDomain} address.`;
   }
 
-  const nickname = String(formData.get("nickname") ?? "").trim();
-  if (nickname.length > 40) errors.nickname = "Keep it under 40 characters.";
+  /*
+   * The name, and it is required now.
+   *
+   * It used to be an optional nickname that fell back to the local part of the
+   * school address. That was the right call while nothing read it, and issue
+   * #36 is the point at which something does: the agent greets the student by
+   * this field, and the fallback produced "Hey jokafor3", which is worse than
+   * no greeting at all. Google cannot supply it either -- the grant requests no
+   * `profile` scope (docs/design/12) -- so the student is asked, once, on a
+   * screen they are already on.
+   */
+  const name = String(formData.get("name") ?? "").trim();
+  if (name.length < 1) errors.name = "Tell us what to call you.";
+  else if (name.length > 40) errors.name = "Keep it under 40 characters.";
+
+  /*
+   * The browser's IANA zone, submitted as a hidden field.
+   *
+   * The server cannot derive it: the request carries no timezone, and the two
+   * things that correlate with one -- the IP and the phone number -- are wrong
+   * for exactly the students most likely to care. See data/notifications.ts.
+   *
+   * Validated rather than trusted. This is a hidden input on a public endpoint,
+   * so it is a claim like any other, and it is the field every future reminder
+   * gets scheduled against. The school's own zone is the fallback, which is a
+   * far better guess than a fixed default for a student at Memorial.
+   */
+  const timeZone = resolveTimeZone(formData.get("timeZone"), school?.timeZone);
 
   // Portal credentials. Google OAuth authorises mail, calendar, and Drive, but
   // it does not create a session on the school's LMS, and the agent has to sign
@@ -250,16 +279,16 @@ export async function completeOnboarding(
     await upsertUser({
       id: profile.userId,
       email,
-      // Google never told us their name: the connector requests neither the
-      // `profile` scope nor returns a name from /auth/callback. The nickname
-      // they chose is the honest answer, and the address is the fallback rather
-      // than inventing something. See docs/design/12 for what a real registrar
-      // name would cost.
-      name: nickname || email.split("@")[0],
+      // What the student typed, with no fallback behind it. Google never told
+      // us their name -- the grant requests no `profile` scope -- so this field
+      // is only ever as good as the question that produced it, which is why the
+      // question is now a required one. See the note at the validation above.
+      name,
       // Already E.164, straight off the verified session. Do not prefix it
       // again; the old form field was ten bare digits and this is not.
       phoneNumber: phone,
       schoolId: school!.id,
+      timeZone,
       consent: {
         terms: record("terms", true),
         sms: record("sms", true),
@@ -346,7 +375,9 @@ export async function joinWaitlist(
     };
   }
 
-  const school = getSchool(String(formData.get("schoolId") ?? "")) ?? findSchoolByEmail(email);
+  const schools = await listSchools();
+  const school =
+    getSchool(schools, String(formData.get("schoolId") ?? "")) ?? findSchoolByEmail(schools, email);
 
   // Already supported. Sending them away to wait for something they can use
   // right now would be the worst possible outcome of this form.

--- a/src/frontend/app/onboarding/callback/route.ts
+++ b/src/frontend/app/onboarding/callback/route.ts
@@ -2,6 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 
 import { getSchool } from "@/data/schools";
 import { getSession } from "@/lib/authSession";
+import { listSchools } from "@/lib/schools";
 import { storeCredential } from "@/lib/credentials";
 import {
   GrantError,
@@ -92,7 +93,7 @@ export async function GET(request: NextRequest) {
   const session = await getSession();
   if (!session) return back({ error: "signin" }, pending.schoolId);
 
-  const school = getSchool(pending.schoolId);
+  const school = getSchool(await listSchools(), pending.schoolId);
   if (!school || school.status !== "live") return back({ error: "school" });
 
   /*

--- a/src/frontend/app/onboarding/page.tsx
+++ b/src/frontend/app/onboarding/page.tsx
@@ -4,6 +4,7 @@ import { OnboardingWizard } from "@/components/onboarding/OnboardingWizard";
 import { OnboardingFrame, WizardSkeleton } from "@/components/onboarding/shell";
 import { getSchool } from "@/data/schools";
 import { getSession } from "@/lib/authSession";
+import { listSchools } from "@/lib/schools";
 import { getUser } from "@/lib/users";
 
 export const metadata: Metadata = {
@@ -48,7 +49,7 @@ export default async function OnboardingPage({
   const { school } = await searchParams;
 
   return (
-    <OnboardingFrame school={school ? getSchool(school) : null}>
+    <OnboardingFrame school={school ? (getSchool(await listSchools(), school) ?? null) : null}>
       {/* Also the boundary useSearchParams needs inside the wizard. */}
       <Suspense fallback={<WizardSkeleton />}>
         <SignedInWizard />

--- a/src/frontend/components/dashboard/NotificationsForm.tsx
+++ b/src/frontend/components/dashboard/NotificationsForm.tsx
@@ -59,7 +59,7 @@ export function NotificationsForm({
 
   return (
     <form action={action} className="flex flex-col gap-6">
-      <input type="hidden" name="timezone" value={timezone} />
+      <input type="hidden" name="timeZone" value={timezone} />
 
       <div className="flex flex-col gap-2.5">
         <Switch

--- a/src/frontend/components/dashboard/ProfileForm.tsx
+++ b/src/frontend/components/dashboard/ProfileForm.tsx
@@ -7,21 +7,25 @@ import { SaveState, buttonClass } from "@/components/dashboard/ui";
 import { Field, TextInput } from "@/components/onboarding/fields";
 
 /**
- * The nickname, which is the only piece of a student's identity that is theirs
- * to set.
+ * The name, which is the only piece of a student's identity that is theirs to
+ * set.
  *
- * Google never told us their name. The connector requests no `profile` scope,
- * so the address is all that comes back from the grant, and onboarding falls
- * back to the part before the @ when a student skips the field. That fallback
- * is why this control matters more than it looks: a good number of accounts are
- * addressed as `jokafor3` until somebody changes it here.
+ * Google never told us their name: the grant requests no `profile` scope, so
+ * the address is all that comes back. Onboarding asks for it outright and
+ * requires it (#36), so for anyone who signed up after that this is an edit
+ * rather than a rescue.
+ *
+ * `name` is nullable because accounts that predate the requirement have none.
+ * It is NOT defaulted to the local part of the address here or by the caller:
+ * that fallback used to render `jokafor3` as a filled-in value, which a student
+ * would then save as though they had chosen it.
  *
  * A read-only display that opens into a field on request, rather than a text
  * input sitting permanently on the page. Everything else in this card is a fact
  * that cannot be edited, so an always-open input beside them reads as though
  * the others should be editable too and are broken.
  */
-export function ProfileForm({ name }: { name: string }) {
+export function ProfileForm({ name }: { name: string | null }) {
   const [state, action, saving] = useActionState(saveProfile, null);
   const [editing, setEditing] = useState(false);
 
@@ -34,7 +38,11 @@ export function ProfileForm({ name }: { name: string }) {
       <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1.5">
         <div className="min-w-0">
           <p className="text-[0.8rem] text-body-soft">What it calls you</p>
-          <p className="mt-1 break-words text-[0.95rem] font-semibold text-ink-900">{name}</p>
+          {/* An account from before the name was required has none. Saying so
+              is better than a blank line, and the button beside it is the fix. */}
+          <p className="mt-1 break-words text-[0.95rem] font-semibold text-ink-900">
+            {name ?? <span className="font-normal text-body-soft">Not set yet</span>}
+          </p>
           <SaveState state={state?.ok ? state : null} />
         </div>
         <button
@@ -52,18 +60,18 @@ export function ProfileForm({ name }: { name: string }) {
     <form action={action} className="flex flex-col gap-4">
       <Field
         label="What it calls you"
-        htmlFor="profile-nickname"
-        error={state?.errors?.nickname}
-        hint="Used at the top of your texts. Nothing else reads it."
+        htmlFor="profile-name"
+        error={state?.errors?.name}
+        hint="Used at the top of your texts, and when Classy greets you."
       >
         <TextInput
           autoFocus
-          id="profile-nickname"
-          name="nickname"
-          defaultValue={name}
+          id="profile-name"
+          name="name"
+          defaultValue={name ?? ""}
           maxLength={40}
           autoComplete="given-name"
-          invalid={Boolean(state?.errors?.nickname)}
+          invalid={Boolean(state?.errors?.name)}
         />
       </Field>
 

--- a/src/frontend/components/landing/HeroStart.tsx
+++ b/src/frontend/components/landing/HeroStart.tsx
@@ -3,8 +3,8 @@
 import Link from "next/link";
 import { useActionState, useEffect, useRef, useState } from "react";
 import { joinWaitlist } from "@/app/onboarding/actions";
-import { useSchoolTheme } from "@/components/theme/SchoolTheme";
-import { LIVE_SCHOOLS, schoolInitials, type School } from "@/data/schools";
+import { useSchoolTheme, useSchools } from "@/components/theme/SchoolTheme";
+import { liveSchools, schoolInitials, type School } from "@/data/schools";
 import { cn } from "@/lib/cn";
 
 /**
@@ -53,6 +53,9 @@ function SchoolCrest({ school, active }: { school: School; active: boolean }) {
  */
 export function HeroStart() {
   const { school, setSchool } = useSchoolTheme();
+  // Derived from the list the root layout read, rather than the LIVE_SCHOOLS
+  // constant this replaced. Same set, but it can now change without a deploy.
+  const live = liveSchools(useSchools());
   /**
    * Reaching for the locked CTA runs a two-beat explanation rather than a dead
    * click. Beat one names the step you skipped; beat two answers the question
@@ -133,12 +136,12 @@ export function HeroStart() {
           : nudge === 2
             ? // Counted, never typed. This sentence used to say "six" and would
               // have quietly become a lie the moment the list changed.
-              `Classistant is only supported at these ${LIVE_SCHOOLS.length} schools.`
+              `Classistant is only supported at these ${live.length} schools.`
             : ""}
       </p>
 
       <div className="mt-3 flex flex-wrap gap-2">
-        {LIVE_SCHOOLS.map((s, i) => {
+        {live.map((s, i) => {
           const on = school?.id === s.id;
           return (
             <button

--- a/src/frontend/components/landing/StartNudge.tsx
+++ b/src/frontend/components/landing/StartNudge.tsx
@@ -2,8 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useSceneClock } from "@/components/landing/sceneParts";
-import { useSchoolTheme } from "@/components/theme/SchoolTheme";
-import { LIVE_SCHOOLS, schoolInitials, type School } from "@/data/schools";
+import { useSchoolTheme, useSchools } from "@/components/theme/SchoolTheme";
+import { liveSchools, schoolInitials, type School } from "@/data/schools";
 import { cn } from "@/lib/cn";
 
 /**
@@ -208,7 +208,9 @@ function NudgeScene() {
   const pressingChip = t >= B.clickChip && t < B.clickChip + 240;
   const pressingCta = t >= B.clickCta && t < B.clickCta + 320;
 
-  const schools = LIVE_SCHOOLS.slice(0, 2);
+  // Two chips, because the scene is a demonstration of the real row rather
+  // than a copy of it.
+  const schools = liveSchools(useSchools()).slice(0, 2);
   const chosen = schools[0];
 
   // The site's own theme colour once a school is picked, exactly as the real
@@ -228,11 +230,25 @@ function NudgeScene() {
   const notHereW = 12 + textWidth("+ Mine is not here", CHIP_TEXT) + 10;
   const notHereX = x;
 
+  /*
+   * `laid[0]` is NOT guaranteed, and assuming it was is a crash.
+   *
+   * The chips come from the school list now, and that list is empty whenever
+   * Firestore is unseeded or unreachable. `chosen` is optional-chained
+   * everywhere below, which made the empty case look handled; this branch was
+   * the one place reading a chip by index. With no chips it threw
+   * "Cannot read properties of undefined" from inside a client render about a
+   * second after the card opened, and there is no error boundary under app/,
+   * so it took the whole landing page with it.
+   *
+   * Reduced motion hid it in testing: it pins the clock to `restAt`, which
+   * takes the third branch and never touches `laid`.
+   */
   const cursor =
     t < B.reachChip
       ? { x: 240, y: 172 }
       : t < B.reachCta
-        ? { x: laid[0].x + 34, y: CHIP_Y + 15 }
+        ? { x: (laid[0]?.x ?? 16) + 34, y: CHIP_Y + 15 }
         : { x: 252, y: 146 };
 
   return (

--- a/src/frontend/components/onboarding/OnboardingWizard.tsx
+++ b/src/frontend/components/onboarding/OnboardingWizard.tsx
@@ -19,7 +19,7 @@ import { Choice, Field, TextInput, formatPhone } from "@/components/onboarding/f
 import { PhoneVerifyScene } from "@/components/onboarding/phoneScenes";
 import { Shell } from "@/components/onboarding/shell";
 import { LogoMark } from "@/components/brand/LogoMark";
-import { useSchoolTheme } from "@/components/theme/SchoolTheme";
+import { useSchoolTheme, useSchools } from "@/components/theme/SchoolTheme";
 import { ACCESS_ITEMS, defaultAccess, type AccessKey } from "@/data/access";
 import { CONSENT_COPY } from "@/data/consent";
 import { getSchool, type School } from "@/data/schools";
@@ -116,10 +116,11 @@ export type ConnectedAccount = {
 export function OnboardingWizard({ connected }: { connected: ConnectedAccount | null }) {
   const params = useSearchParams();
   const { school: themedSchool, setSchool } = useSchoolTheme();
+  const schools = useSchools();
 
   const preselected = params.get("school") ?? connected?.schoolId;
   const [school, setLocalSchool] = useState<School | null>(
-    preselected ? (getSchool(preselected) ?? null) : null,
+    preselected ? (getSchool(schools, preselected) ?? null) : null,
   );
   const [unsupported, setUnsupported] = useState<School | null>(null);
 
@@ -157,12 +158,40 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
    * page load, so there is no moment where this component learns it on its own.
    * Holding it in state would only create somewhere for a stale value to live.
    */
-  const identity: Identity | null = connected?.email
-    ? { email: connected.email, name: connected.email.split("@")[0] }
-    : null;
+  const identity: Identity | null = connected?.email ? { email: connected.email } : null;
 
-  const [nickname, setNickname] = useState("");
-  const [editingNickname, setEditingNickname] = useState(false);
+  /*
+   * The student's name, asked for rather than guessed.
+   *
+   * It used to default to the local part of the school address and was editable
+   * behind a "Change nickname" link most people never pressed. Nothing read it,
+   * so that was free. Issue #36 made the agent greet students by it, at which
+   * point the default started producing "Hey jokafor3" and the field had to
+   * become a real question. Google cannot answer it for us: the grant requests
+   * no `profile` scope, by decision, see docs/design/12.
+   */
+  const [name, setName] = useState("");
+
+  /*
+   * The browser's IANA zone, carried to the server on the final submit.
+   *
+   * Same reasoning as the settings form: the request carries no timezone, and
+   * the IP and the area code are both wrong for the students most likely to
+   * care. Read in an effect rather than during render because
+   * `Intl.DateTimeFormat` is a browser API and the first paint is the server's.
+   *
+   * Empty is a fine value to submit. `resolveTimeZone` falls back to the
+   * school's own campus zone, which is a better guess than any fixed default.
+   */
+  const [timeZone, setTimeZone] = useState("");
+  useEffect(() => {
+    try {
+      setTimeZone(Intl.DateTimeFormat().resolvedOptions().timeZone ?? "");
+    } catch {
+      // No Intl, or a browser that will not name the zone. The school's zone
+      // is what the student gets, which is what the server does with "".
+    }
+  }, []);
 
   /*
    * Step 0. `pending` is Firebase's handle on the code it just texted; holding
@@ -213,11 +242,23 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
    * a clause inside the first.
    */
   const consentsGiven = acceptTerms && consentSms;
-  const missingConsent = !acceptTerms
-    ? consentSms
-      ? "Accept the terms and privacy policy to finish."
-      : "Accept the terms, and agree to the texts, to finish."
-    : "Agree to receive the texts to finish.";
+
+  /*
+   * The name joins the two consents in gating the button, for the same reason
+   * they do: the server rejects a submit without it, and a student should find
+   * that out before pressing rather than after. It is listed first in the
+   * message because it is the field they can see and the consents are boxes
+   * they have to scroll past.
+   */
+  const named = name.trim().length > 0;
+  const canFinish = named && consentsGiven;
+  const missingRequirement = !named
+    ? "Tell us what to call you to finish."
+    : !acceptTerms
+      ? consentSms
+        ? "Accept the terms and privacy policy to finish."
+        : "Accept the terms, and agree to the texts, to finish."
+      : "Agree to receive the texts to finish.";
 
   const [busy, setBusy] = useState(false);
   const [connectError, setConnectError] = useState<string | null>(null);
@@ -295,7 +336,7 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
        */
       if (data.email) setSchoolEmail(data.email);
       if (data.schoolId && !school) {
-        setLocalSchool(getSchool(data.schoolId) ?? null);
+        setLocalSchool(getSchool(schools, data.schoolId) ?? null);
       }
 
       // Already granted on an earlier visit, so the consent screen has nothing
@@ -383,7 +424,7 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
   if (submitState?.ok) {
     return (
       <DoneScreen
-        name={nickname || identity?.name || ""}
+        name={name}
         phone={verifiedPhone ?? phone}
         school={school}
       />
@@ -857,38 +898,36 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
               </p>
 
               <dl className="mt-4 flex flex-col gap-4">
+                {/*
+                  An always-open field, not a value with a "change" link beside
+                  it. The other two rows in this card are facts that were proven
+                  and cannot be edited; this one is the only thing on the card
+                  we do not know, and rendering it like its neighbours was what
+                  let almost everybody leave it at the address-derived default.
+
+                  The placeholder is a prompt, not a specimen value. Putting
+                  `localPart` in there was tried on the portal username field
+                  and reads exactly like a filled-in input, which is how a
+                  student ends up staring at a disabled button.
+                */}
                 <div>
-                  <dt className="text-[0.8rem] text-body-soft">Name</dt>
-                  {editingNickname ? (
+                  <Field
+                    label="Your name"
+                    htmlFor="student-name"
+                    error={errors.name}
+                    hint="What Classy calls you in every text. A first name is plenty."
+                  >
                     <TextInput
-                      autoFocus
-                      name="nickname"
-                      value={nickname}
-                      onChange={(e) => setNickname(e.target.value)}
-                      onBlur={() => setEditingNickname(false)}
-                      placeholder="What should it call you?"
-                      className="mt-1"
-                      invalid={Boolean(errors.nickname)}
+                      id="student-name"
+                      name="name"
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                      placeholder="What should we call you?"
+                      maxLength={40}
+                      autoComplete="given-name"
+                      invalid={Boolean(errors.name)}
                     />
-                  ) : (
-                    <dd className="mt-0.5 flex flex-wrap items-center gap-3">
-                      <span className="text-[1.02rem] font-semibold text-ink-900">
-                        {nickname || identity?.name || localPart}
-                      </span>
-                      <button
-                        type="button"
-                        onClick={() => setEditingNickname(true)}
-                        className="text-[0.82rem] font-semibold text-brand-600 hover:underline"
-                      >
-                        Change nickname
-                      </button>
-                    </dd>
-                  )}
-                  {!nickname ? (
-                    <p className="mt-1.5 text-[0.76rem] text-body-soft">
-                      Taken from your address. Change it to whatever you want to be called.
-                    </p>
-                  ) : null}
+                  </Field>
                 </div>
 
                 <div>
@@ -963,7 +1002,11 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
         <HiddenState
           step={step}
           values={{
-            nickname,
+            name,
+            // Never rendered as a visible control on any step, so it is only
+            // ever here. The student has nothing to say about it: it is what
+            // their browser reports.
+            timeZone,
             portalUser,
             portalPassword,
             acceptTerms: acceptTerms ? "on" : "",
@@ -985,6 +1028,22 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
         {submitState && !submitState.ok ? (
           <p role="alert" className="mt-6 rounded-xl bg-paper p-4 text-[0.86rem] text-ink-800 ring-1 ring-line">
             {submitState.message}
+            {/*
+              `schoolId` and `email` have no field on this screen to attach to,
+              and without this they were set by the server and rendered nowhere:
+              the student got a bare "Some details still need fixing" while
+              every visible input was filled in correctly. Both are reachable --
+              schoolId whenever the school catalogue could not be read, email if
+              the address stops matching the school's domain -- and neither is
+              something the student can fix from here, so the message has to at
+              least say what happened.
+            */}
+            {errors.schoolId || errors.email ? (
+              <span className="mt-2 block text-body">
+                {errors.schoolId ?? errors.email} Reload the page and try again, and if it
+                keeps happening it is our end, not yours.
+              </span>
+            ) : null}
           </p>
         ) : null}
 
@@ -1020,7 +1079,7 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
             <div className="flex flex-col items-end gap-2">
               <button
                 type="submit"
-                disabled={submitting || !consentsGiven}
+                disabled={submitting || !canFinish}
                 className="rounded-xl bg-brand-600 px-8 py-4 text-[1rem] font-bold text-white shadow-[0_12px_28px_-12px_var(--color-brand-600)] transition-colors hover:bg-brand-700 disabled:cursor-not-allowed disabled:bg-line disabled:text-body-soft disabled:shadow-none"
               >
                 {submitting ? "Sending..." : "Send welcome gift"}
@@ -1030,9 +1089,9 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
                   after. A disabled control with no stated reason is the trap
                   the portal username field fell into: a student reads it as
                   broken, because nothing on screen tells them otherwise. */}
-              {!consentsGiven && !submitting ? (
+              {!canFinish && !submitting ? (
                 <p className="text-right text-[0.8rem] leading-[1.5] text-body-soft">
-                  {missingConsent}
+                  {missingRequirement}
                 </p>
               ) : null}
             </div>
@@ -1144,7 +1203,7 @@ function HiddenState({ step, values }: { step: number; values: Record<string, st
     // number and the code are deliberately absent from the form entirely:
     // neither is submitted, they reach the server by being verified.
     2: ["portalUser", "portalPassword"],
-    3: ["nickname", "acceptTerms", "consentSms", "acceptMarketing"],
+    3: ["name", "acceptTerms", "consentSms", "acceptMarketing"],
   };
   const skip = new Set(rendered[step] ?? []);
   return (

--- a/src/frontend/components/onboarding/SchoolPicker.tsx
+++ b/src/frontend/components/onboarding/SchoolPicker.tsx
@@ -121,26 +121,14 @@ export function SchoolPicker({
           );
         })}
 
-        {/*
-          Two different empty states, and telling them apart is the whole reason
-          lib/schools.ts refuses to fall back to a hardcoded list. An empty
-          collection or a failed read is our problem, and saying "no match for
-          Brock" when we never loaded a list at all would send the student off
-          to check their spelling for a bug on our side.
-        */}
+        {/* Only one empty state to render. `listSchools` falls back to the
+            seeded catalogue rather than returning nothing, so a student can
+            never reach this screen with no schools to search -- which means
+            "no results" always means what it says, and never a failed read. */}
         {results.length === 0 ? (
           <li className="rounded-xl border border-dashed border-line bg-paper p-5 text-center text-[0.88rem] text-body">
-            {schools.length === 0 ? (
-              <>
-                We could not load the school list just now. Reload the page, and if it keeps
-                happening it is our end, not yours.
-              </>
-            ) : (
-              <>
-                No match for &ldquo;{query}&rdquo;. Classistant only works where student email
-                runs on Google, so the list is short on purpose.
-              </>
-            )}
+            No match for &ldquo;{query}&rdquo;. Classistant only works where student email runs
+            on Google, so the list is short on purpose.
           </li>
         ) : null}
       </ul>

--- a/src/frontend/components/onboarding/SchoolPicker.tsx
+++ b/src/frontend/components/onboarding/SchoolPicker.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { SCHOOLS, type School } from "@/data/schools";
+import { searchSchools, type School } from "@/data/schools";
+import { useSchools } from "@/components/theme/SchoolTheme";
 import { TextInput } from "@/components/onboarding/fields";
 import { cn } from "@/lib/cn";
 
@@ -23,24 +24,13 @@ export function SchoolPicker({
   onUnsupported: (school: School) => void;
 }) {
   const [query, setQuery] = useState("");
+  const schools = useSchools();
 
-  const results = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    const matched = q
-      ? SCHOOLS.filter((s) =>
-          [s.name, s.short ?? "", s.emailDomain, s.province].some((f) =>
-            f.toLowerCase().includes(q),
-          ),
-        )
-      : SCHOOLS;
-    // Supported first, then confirmed-but-unopened, then unchecked, and
-    // alphabetical inside each group. A plain `live ? -1 : 1` was fine while
-    // there were two statuses; with three it sorted `pending` above `soon`.
-    const rank = { live: 0, soon: 1, pending: 2 };
-    return [...matched].sort(
-      (a, b) => rank[a.status] - rank[b.status] || a.name.localeCompare(b.name),
-    );
-  }, [query]);
+  // No local sort any more. `listSchools` orders the collection by status and
+  // then by name before it ever reaches the browser (lib/schools.ts), so
+  // re-sorting here would be a second copy of that rule, free to disagree with
+  // the first the next time either is edited.
+  const results = useMemo(() => searchSchools(schools, query), [schools, query]);
 
   return (
     <div className="flex flex-col gap-3">
@@ -131,10 +121,26 @@ export function SchoolPicker({
           );
         })}
 
+        {/*
+          Two different empty states, and telling them apart is the whole reason
+          lib/schools.ts refuses to fall back to a hardcoded list. An empty
+          collection or a failed read is our problem, and saying "no match for
+          Brock" when we never loaded a list at all would send the student off
+          to check their spelling for a bug on our side.
+        */}
         {results.length === 0 ? (
           <li className="rounded-xl border border-dashed border-line bg-paper p-5 text-center text-[0.88rem] text-body">
-            No match for &ldquo;{query}&rdquo;. Classistant only works where student email runs
-            on Google, so the list is short on purpose.
+            {schools.length === 0 ? (
+              <>
+                We could not load the school list just now. Reload the page, and if it keeps
+                happening it is our end, not yours.
+              </>
+            ) : (
+              <>
+                No match for &ldquo;{query}&rdquo;. Classistant only works where student email
+                runs on Google, so the list is short on purpose.
+              </>
+            )}
           </li>
         ) : null}
       </ul>

--- a/src/frontend/components/theme/SchoolTheme.tsx
+++ b/src/frontend/components/theme/SchoolTheme.tsx
@@ -13,7 +13,8 @@ import { MANAGED, themeVars } from "@/components/theme/themeVars";
 import { getSchool, type School } from "@/data/schools";
 
 /**
- * Re-skins the entire site in a school's own colours.
+ * Re-skins the entire site in a school's own colours, and carries the school
+ * list to every client component that needs it.
  *
  * Picking a school is the first step of getting started, so the site answering
  * in your school's colours is both the confirmation that it recognised you and
@@ -23,22 +24,60 @@ import { getSchool, type School } from "@/data/schools";
  * `color-mix`, rather than hand-picking a ramp per school. That keeps contrast
  * relationships identical across all six themes, so nothing has to be re-checked
  * for legibility when a school is added.
+ *
+ * ## Why the list rides along in here
+ *
+ * The schools moved into Firestore for issue #36, which only a server component
+ * can read. Five client components need the list -- the picker, the hero, the
+ * start nudge, the wizard, and this provider itself -- and the alternative to
+ * one shared context is five prop chains threaded through layouts that
+ * otherwise have no interest in schools.
+ *
+ * This provider was already the right place: it is mounted once in the root
+ * layout, above everything, and it already existed to answer "which school" for
+ * the whole tree. `useSchools()` is the read for anything that needs the list;
+ * `useSchoolTheme()` stays what it was, for anything that only needs the
+ * current one.
  */
 
 type Ctx = {
   school: School | null;
   setSchool: (id: string | null) => void;
+  /** Every school, as read from Firestore by the root layout. Empty when the
+   *  collection is unseeded or the read failed, which callers must render for
+   *  rather than assume away. */
+  schools: School[];
 };
 
-const SchoolThemeContext = createContext<Ctx>({ school: null, setSchool: () => {} });
+const SchoolThemeContext = createContext<Ctx>({
+  school: null,
+  setSchool: () => {},
+  schools: [],
+});
 
 export function useSchoolTheme() {
   return useContext(SchoolThemeContext);
 }
 
-export function SchoolThemeProvider({ children }: { children: React.ReactNode }) {
+/** The school list, for client components that need more than the current one.
+ *  Returns `[]` rather than throwing when the collection could not be read, so
+ *  a picker renders its own "could not load" state instead of a boundary. */
+export function useSchools(): School[] {
+  return useContext(SchoolThemeContext).schools;
+}
+
+export function SchoolThemeProvider({
+  schools,
+  children,
+}: {
+  schools: School[];
+  children: React.ReactNode;
+}) {
   const [schoolId, setSchoolId] = useState<string | null>(null);
-  const school = useMemo(() => (schoolId ? getSchool(schoolId) ?? null : null), [schoolId]);
+  const school = useMemo(
+    () => (schoolId ? getSchool(schools, schoolId) ?? null : null),
+    [schools, schoolId],
+  );
 
   /*
    * Whether this run is the mount rather than a real switch.
@@ -84,7 +123,7 @@ export function SchoolThemeProvider({ children }: { children: React.ReactNode })
   }, [school]);
 
   const setSchool = useCallback((id: string | null) => setSchoolId(id), []);
-  const value = useMemo(() => ({ school, setSchool }), [school, setSchool]);
+  const value = useMemo(() => ({ school, setSchool, schools }), [school, setSchool, schools]);
 
   return <SchoolThemeContext.Provider value={value}>{children}</SchoolThemeContext.Provider>;
 }

--- a/src/frontend/data/notifications.ts
+++ b/src/frontend/data/notifications.ts
@@ -20,6 +20,8 @@
  * their own timezone is a rule they can verify by looking at it.
  */
 
+import { FALLBACK_TIME_ZONE } from "@/lib/timeZone";
+
 /** Stored as one map on the user document. Snake case to match every other
  *  field there; the TypeScript shape below is camel. */
 export const NOTIFICATIONS_FIELD = "notifications";
@@ -48,10 +50,19 @@ export type NotificationPrefs = {
    *  not cancelled, which is the reader's job and not this file's. */
   digestHour: number | null;
   /**
-   * IANA zone the two clocks above are read in. Captured from the browser
-   * rather than derived from the phone number: an area code says where a number
-   * was issued, not where its owner is now, and a student from Toronto studying
-   * in Alberta would get woken up an hour early by that inference.
+   * IANA zone the two clocks above are read in.
+   *
+   * NOT stored in this map. It is `time_zone` at the top level of the user
+   * document, and it is passed in here so the hours have something to be
+   * rendered against. Issue #36 moved it out: the agent schedules against it
+   * and should not have to reach into a preferences map to find it, and two
+   * copies of a timezone on one document is a bug with a clock on it. See
+   * lib/timeZone.ts.
+   *
+   * Captured from the browser rather than derived from the phone number: an
+   * area code says where a number was issued, not where its owner is now, and a
+   * student from Toronto studying in Alberta would get woken up an hour early
+   * by that inference.
    */
   timezone: string;
 };
@@ -74,7 +85,7 @@ export function defaultNotifications(): NotificationPrefs {
     quietEnd: 8,
     calls: true,
     digestHour: null,
-    timezone: "America/Toronto",
+    timezone: FALLBACK_TIME_ZONE,
   };
 }
 
@@ -117,8 +128,13 @@ export function inQuietHours(prefs: NotificationPrefs, hour: number): boolean {
  * and treating that as "no preferences at all" would silently discard the ones
  * they did set.
  */
-export function readNotifications(raw: unknown): NotificationPrefs {
+export function readNotifications(raw: unknown, timeZone?: string | null): NotificationPrefs {
   const base = defaultNotifications();
+  // Taken from the caller, which read it off the top level of the document.
+  // A pre-#36 document has neither that field nor the one that used to be in
+  // this map, and both cases land on the default rather than on nothing.
+  if (timeZone) base.timezone = timeZone;
+
   if (typeof raw !== "object" || raw === null) return base;
   const data = raw as Record<string, unknown>;
 
@@ -137,18 +153,39 @@ export function readNotifications(raw: unknown): NotificationPrefs {
     quietEnd: hour("quiet_end", base.quietEnd),
     calls: typeof data.calls === "boolean" ? data.calls : base.calls,
     digestHour: hour("digest_hour", base.digestHour),
-    timezone: typeof data.timezone === "string" && data.timezone ? data.timezone : base.timezone,
+    /*
+     * The pre-#36 key, read as a fallback and only as a fallback.
+     *
+     * An earlier version of this dropped it, on the reasoning that letting the
+     * stale copy win would defeat the migration. That reasoning does not
+     * survive the control flow directly above: `base.timezone` has ALREADY been
+     * overwritten with the top-level `time_zone` when the caller had one, so
+     * the top-level field wins here whenever it exists. The only documents this
+     * line can decide are the ones with no top-level field at all -- which is
+     * every account that set a zone before this change, and dropping it reset
+     * all of them to Toronto without anyone touching a control. A student in
+     * Vancouver would have had their quiet hours silently move three hours.
+     *
+     * So it stays until those documents are backfilled. It is dead weight for
+     * anyone who has saved since, and harmless for them, because they cannot
+     * reach it.
+     */
+    timezone:
+      timeZone ??
+      (typeof data.timezone === "string" && data.timezone ? data.timezone : base.timezone),
   };
 }
 
 /** The inverse, for the write path. Kept beside the reader so the two field
- *  name lists cannot drift apart unnoticed. */
+ *  name lists cannot drift apart unnoticed.
+ *
+ *  No `timezone` key: it is written to the top level of the document by
+ *  `updateTimeZone`, not into this map. */
 export function writeNotifications(prefs: NotificationPrefs): Record<string, unknown> {
   return {
     quiet_start: prefs.quietStart,
     quiet_end: prefs.quietEnd,
     calls: prefs.calls,
     digest_hour: prefs.digestHour,
-    timezone: prefs.timezone,
   };
 }

--- a/src/frontend/data/schools.seed.ts
+++ b/src/frontend/data/schools.seed.ts
@@ -1,20 +1,26 @@
 import type { School } from "@/data/schools";
 
 /**
- * The verified school catalogue, and the input to `npm run seed:schools`.
+ * The verified school catalogue: the input to `npm run seed:schools`, and the
+ * fallback the app serves when Firestore gives it nothing.
  *
- * ## This file is not read at runtime
+ * ## Firestore is the source of truth, this is the floor
  *
- * Firestore's `schools` collection is the source of truth the app reads from
- * (lib/schools.ts). This array is what that collection is *seeded* from, which
- * is why it lives under scripts/ rather than data/: importing it from a page
- * would recreate the second, silently disagreeing copy that moving to Firestore
- * was meant to remove. Nothing outside the seeder may import it.
+ * `lib/schools.ts` reads the `schools` collection, and whatever it finds there
+ * wins. This array is used in exactly one case: the collection came back empty
+ * or unreadable. An empty school picker means a student cannot start at all,
+ * and losing a signup to a Firestore hiccup is a worse outcome than serving a
+ * list that might be a few days behind the console (@obaodelana on PR #42).
  *
- * Editing a school in the Firestore console is therefore a legitimate way to
- * change what students see, and issue #36 asked for exactly that. What it costs
- * is the review gate below, so an edit made in the console should be brought
- * back here in the same week, or the next seed run will quietly revert it.
+ * The cost is a second copy that can disagree with the first, so the disagreement
+ * is made loud rather than silent: `listSchools` logs an error every time it
+ * falls through to this, and the log says the catalogue is being served.
+ *
+ * Editing a school in the Firestore console is a legitimate way to change what
+ * students see, and issue #36 asked for exactly that. What it costs is the
+ * review gate below, so an edit made in the console should be brought back here
+ * in the same week, or the next seed run will quietly revert it -- and until it
+ * is, this fallback would serve the pre-edit value if Firestore ever went down.
  *
  * ## Rules for this list (see docs/design/05-schools-data.md)
  *

--- a/src/frontend/data/schools.ts
+++ b/src/frontend/data/schools.ts
@@ -5,7 +5,7 @@
  *
  * It used to be a `SCHOOLS` constant in this file, and it is now the `schools`
  * collection in Firestore, read by lib/schools.ts and seeded from
- * scripts/schools.seed.ts. Issue #36 moved it so that a school can be added
+ * data/schools.seed.ts. Issue #36 moved it so that a school can be added
  * without a deploy, and so the agent can resolve a `school_id` into a real name
  * and location without a copy of this list on its side.
  *
@@ -16,7 +16,7 @@
  * prop, and neither can afford this module to reach for a database.
  *
  * So the rule is: this file holds no schools, and nothing in it imports
- * scripts/schools.seed.ts. The eligibility rules that govern which schools may
+ * data/schools.seed.ts. The eligibility rules that govern which schools may
  * exist at all live with the data, in the seed file's header and in
  * docs/design/05-schools-data.md.
  */

--- a/src/frontend/data/schools.ts
+++ b/src/frontend/data/schools.ts
@@ -1,33 +1,24 @@
 /**
- * Canadian institutions whose STUDENT email runs on Google Workspace for Education.
+ * The shape of a school, and the pure functions over a list of them.
  *
- * Classistant signs in with Google, so a school only works if its student
- * mailbox is a Google mailbox. A school being "on Google" for Drive or Meet is
- * not enough, the mail has to be Gmail.
+ * ## Where the list itself went
  *
- * Rules for this file (see docs/design/05-schools-data.md):
- *  - Nothing goes in as `live` without a `source` URL from the school's own IT
- *    pages. We put institution names on a public marketing page, so a wrong
- *    entry is a factual error about a real organisation, not a cosmetic bug.
- *  - Platforms migrate. Re-verify every entry each August before term starts.
+ * It used to be a `SCHOOLS` constant in this file, and it is now the `schools`
+ * collection in Firestore, read by lib/schools.ts and seeded from
+ * scripts/schools.seed.ts. Issue #36 moved it so that a school can be added
+ * without a deploy, and so the agent can resolve a `school_id` into a real name
+ * and location without a copy of this list on its side.
  *
- * Three statuses, and the difference between the last two matters:
- *  - `live`    We run there today. Only these appear in marketing copy.
- *  - `soon`    Student mail CONFIRMED on Google, with a source, but we have not
- *              launched there. Launch scope, not a research gap.
- *  - `pending` Not checked yet. We do not know what their mail runs on.
+ * What is left here is everything that does NOT need to know where the data
+ * came from: the type, and five functions that take a list and return an answer
+ * about it. They are pure on purpose. Onboarding runs them on the server, the
+ * hero and the picker run them in the browser against a list that arrived as a
+ * prop, and neither can afford this module to reach for a database.
  *
- * `soon` and `pending` both read as unsupported to a student, so onboarding
- * treats them the same. They are kept apart here because collapsing them would
- * throw away confirmed verification work and quietly invite someone to redo it.
- *
- * Known NOT eligible (student mail is Microsoft 365), keep out of the list:
- *  - Carleton University (cmail is M365)
- *  - University of Winnipeg (self-hosted webmail)
- *
- * Note on Office 365: several schools hand out Office desktop apps while student
- * MAIL still lives on Google. Availability of Office is not disqualifying, the
- * mailbox platform is what matters.
+ * So the rule is: this file holds no schools, and nothing in it imports
+ * scripts/schools.seed.ts. The eligibility rules that govern which schools may
+ * exist at all live with the data, in the seed file's header and in
+ * docs/design/05-schools-data.md.
  */
 
 export type SchoolStatus = "live" | "soon" | "pending";
@@ -36,10 +27,10 @@ export type SchoolStatus = "live" | "soon" | "pending";
  * A school's own brand colours, used to re-skin the whole site when a student
  * picks their school in the hero.
  *
- * Same rule as the rest of this file: every value is taken from the school's
- * published brand guidelines, with `source` recorded. Students know their own
- * school's colours on sight, so a guessed hex is immediately visible as wrong.
- * `accent` is only a second official colour where the school publishes one.
+ * Every value is taken from the school's published brand guidelines, with
+ * `source` recorded. Students know their own school's colours on sight, so a
+ * guessed hex is immediately visible as wrong. `accent` is only a second
+ * official colour where the school publishes one.
  */
 export type SchoolBrand = {
   primary: string;
@@ -55,6 +46,18 @@ export type School = {
   /** Short form used in tight UI, falls back to `name`. */
   short?: string;
   province: string;
+  /** Main campus city. Part of the "location" the agent asked for in #36: a
+   *  province is too coarse to say anything useful to a student with it. */
+  city: string;
+  /**
+   * IANA zone of the main campus.
+   *
+   * The fallback a reminder is scheduled in when a student's own `time_zone` is
+   * missing. Deliberately stored per school rather than derived from
+   * `province`, because Newfoundland is UTC-3:30 and any mapping from a
+   * two-letter province code would put every Memorial reminder half an hour out.
+   */
+  timeZone: string;
   /** Student mail domain, shown so a student can confirm it is their address. */
   emailDomain: string;
   status: SchoolStatus;
@@ -84,152 +87,30 @@ export function schoolInitials(name: string): string {
     .slice(0, 3);
 }
 
-export const SCHOOLS: School[] = [
-  // ---------------------------------------------------------------- live
-  {
-    id: "ualberta",
-    name: "University of Alberta",
-    short: "U of A",
-    province: "AB",
-    emailDomain: "ualberta.ca",
-    status: "live",
-    source:
-      "https://www.ualberta.ca/en/information-services-and-technology/initiatives/google-workspace-changes/index.html",
-    // "Sign in with your CCID" was the first sentence here. The field it sits
-    // under now says "Student email" and prints @ualberta.ca beside the input,
-    // which answers what to type without the jargon. What is left is the part
-    // the form cannot show you.
-    note: "Google access ends when your account moves to alumni status.",
-    brand: {
-      primary: "#007C41",
-      accent: "#FFDB05",
-      source: "https://www.ualberta.ca/toolkit/visual-identity/our-colours",
-    },
-  },
-  {
-    id: "ontariotech",
-    name: "Ontario Tech University",
-    short: "Ontario Tech",
-    province: "ON",
-    emailDomain: "ontariotechu.net",
-    status: "live",
-    // Student Google Workspace is branded "OntarioTechU.Net" on their own IT
-    // pages, which is why searching for "Ontario Tech Microsoft 365" is
-    // misleading: that page is real, but it covers faculty and staff mail.
-    // Students are on Gmail.
-    source:
-      "https://itsc.ontariotechu.ca/ontariotechunet-google-apps-for-education/google-email-gmail.php",
-    note: "Undergraduates, graduates, and alumni all get an OntarioTechU.Net account.",
-    brand: {
-      primary: "#003C71",
-      accent: "#E75D2A",
-      source:
-        "https://brand.ontariotechu.ca/guidelines/brand-standards/colours-design-graphics-and-fonts/colours.php",
-    },
-  },
+/**
+ * The schools we actually run at, which is the only set marketing may name.
+ *
+ * A function over a list rather than the `LIVE_SCHOOLS` constant it replaced.
+ * The constant could be computed once at module load because the list was a
+ * literal in this file; now the list arrives at runtime and differs between a
+ * seeded database and an empty one, so the filter has to run where it is used.
+ */
+export function liveSchools(schools: School[]): School[] {
+  return schools.filter((s) => s.status === "live");
+}
 
-  // ------------------------------------------------- confirmed, not launched
-  // Student mail verified on Google against the sources below. These are out of
-  // launch scope, not unverified. Flip to `live` when we open the campus.
-  {
-    id: "tmu",
-    name: "Toronto Metropolitan University",
-    short: "TMU",
-    province: "ON",
-    emailDomain: "torontomu.ca",
-    status: "soon",
-    source: "https://www.torontomu.ca/google/",
-    brand: { primary: "#004C9B", source: "https://www.torontomu.ca/brand/brand-toolkit/colours/" },
-  },
-  {
-    id: "yorku",
-    name: "York University",
-    short: "York",
-    province: "ON",
-    emailDomain: "my.yorku.ca",
-    status: "soon",
-    source: "https://google.info.yorku.ca/",
-    note: "Undergraduate accounts only. Graduate mail at yorku.ca is on a different platform.",
-    brand: { primary: "#E31837", source: "https://www.yorku.ca/brand/using-the-brand/colours/" },
-  },
-  {
-    id: "lakehead",
-    name: "Lakehead University",
-    short: "Lakehead",
-    province: "ON",
-    emailDomain: "lakeheadu.ca",
-    status: "soon",
-    source:
-      "https://www.lakeheadu.ca/faculty-and-staff/departments/services/helpdesk/email",
-    brand: {
-      primary: "#004271",
-      accent: "#FFC20E",
-      source:
-        "https://www.lakeheadu.ca/faculty-and-staff/departments/services/marketing-communications/marketing/brand-guidelines",
-    },
-  },
-  {
-    id: "mun",
-    name: "Memorial University of Newfoundland",
-    short: "Memorial",
-    province: "NL",
-    emailDomain: "mun.ca",
-    status: "soon",
-    source:
-      "https://www.mun.ca/cio/it-services/communication-and-collaboration/google-workspace/",
-    note: "Access requires registration within the last three semesters.",
-    brand: {
-      primary: "#862633",
-      source:
-        "https://www.mun.ca/marcomm/media/production/memorial/administrative/marcomm/files/BrandStandards_August_2017_FA.pdf",
-    },
-  },
-  {
-    id: "mtroyal",
-    name: "Mount Royal University",
-    short: "Mount Royal",
-    province: "AB",
-    emailDomain: "mtroyal.ca",
-    status: "soon",
-    source:
-      "https://www.mtroyal.ca/CampusServices/CampusResources/InformationTechnology/EmailCalendaring/index.htm",
-    brand: {
-      primary: "#003352",
-      accent: "#007FB5",
-      source: "https://www.mtroyal.ca/AboutMountRoyal/Brand/index.htm",
-    },
-  },
-
-  // ------------------------------------------------------------- not checked
-  // Mail platform unknown. Searchable during onboarding so a student gets a real
-  // answer, never shown as supported. Confirm against the school's own IT mail
-  // page before promoting, and add the `source` in the same commit.
-  { id: "kpu", name: "Kwantlen Polytechnic University", short: "KPU", province: "BC", emailDomain: "student.kpu.ca", status: "pending" },
-  { id: "seneca", name: "Seneca Polytechnic", short: "Seneca", province: "ON", emailDomain: "myseneca.ca", status: "pending" },
-  { id: "sheridan", name: "Sheridan College", short: "Sheridan", province: "ON", emailDomain: "sheridancollege.ca", status: "pending" },
-  { id: "brock", name: "Brock University", short: "Brock", province: "ON", emailDomain: "brocku.ca", status: "pending" },
-  { id: "trent", name: "Trent University", short: "Trent", province: "ON", emailDomain: "trentu.ca", status: "pending" },
-  { id: "nipissing", name: "Nipissing University", short: "Nipissing", province: "ON", emailDomain: "nipissingu.ca", status: "pending" },
-  { id: "viu", name: "Vancouver Island University", short: "VIU", province: "BC", emailDomain: "viu.ca", status: "pending" },
-  { id: "tru", name: "Thompson Rivers University", short: "TRU", province: "BC", emailDomain: "mytru.ca", status: "pending" },
-  { id: "smu", name: "Saint Mary's University", short: "Saint Mary's", province: "NS", emailDomain: "smu.ca", status: "pending" },
-  { id: "cbu", name: "Cape Breton University", short: "CBU", province: "NS", emailDomain: "cbu.ca", status: "pending" },
-];
-
-export const LIVE_SCHOOLS = SCHOOLS.filter((s) => s.status === "live");
-
-export function searchSchools(query: string): School[] {
+export function searchSchools(schools: School[], query: string): School[] {
   const q = query.trim().toLowerCase();
-  if (!q) return SCHOOLS;
-  return SCHOOLS.filter((s) =>
-    [s.name, s.short ?? "", s.emailDomain, s.province].some((field) =>
+  if (!q) return schools;
+  return schools.filter((s) =>
+    [s.name, s.short ?? "", s.emailDomain, s.province, s.city].some((field) =>
       field.toLowerCase().includes(q),
     ),
   );
 }
 
-export function getSchool(id: string): School | undefined {
-  return SCHOOLS.find((s) => s.id === id);
+export function getSchool(schools: School[], id: string): School | undefined {
+  return schools.find((s) => s.id === id);
 }
 
 /**
@@ -241,12 +122,12 @@ export function getSchool(id: string): School | undefined {
  * `@yorku.ca` about as often. A `pending` school matches too: we do not know
  * what their mail runs on, but we do know what the school is called.
  */
-export function findSchoolByEmail(email: string): School | undefined {
+export function findSchoolByEmail(schools: School[], email: string): School | undefined {
   const domain = email.trim().toLowerCase().split("@")[1]?.replace(/[>\s]+$/, "");
   // A bare TLD would `endsWith`-match half the list, so require a real domain.
   if (!domain || !domain.includes(".")) return undefined;
 
-  return SCHOOLS.find(
+  return schools.find(
     (s) =>
       domain === s.emailDomain ||
       domain.endsWith(`.${s.emailDomain}`) ||

--- a/src/frontend/lib/schools.ts
+++ b/src/frontend/lib/schools.ts
@@ -3,6 +3,7 @@ import "server-only";
 import { unstable_cache } from "next/cache";
 
 import type { School, SchoolStatus } from "@/data/schools";
+import { SEED_SCHOOLS } from "@/data/schools.seed";
 import { firestore } from "@/lib/firebaseAdmin";
 
 /**
@@ -12,15 +13,22 @@ import { firestore } from "@/lib/firebaseAdmin";
  * Issue #36 moved this out of a TypeScript constant so that a school can be
  * added or corrected without a deploy, and so the agent can turn the
  * `school_id` on a user document into a real name, city, and timezone. The
- * catalogue is seeded from scripts/schools.seed.ts by `npm run seed:schools`.
+ * catalogue is seeded from data/schools.seed.ts by `npm run seed:schools`.
  *
- * ## Why there is no fallback to the seed array
+ * ## The seed catalogue is the floor, and the fallthrough is loud
  *
- * There deliberately is not one. A hardcoded list that stands in when Firestore
- * is empty or unreachable is a second copy of the data that disagrees with the
- * first, silently, on exactly the days someone is debugging why a school
- * vanished. An empty list is a visible failure and a wrong list is not, so this
- * returns `[]` and the surfaces above it say they could not load the schools.
+ * When the collection comes back empty or unreadable, `listSchools` serves
+ * `SEED_SCHOOLS` from data/schools.seed.ts rather than an empty list.
+ *
+ * The first version of this refused to, on the grounds that a second copy of
+ * the data can silently disagree with the first. That is a real cost and it is
+ * the wrong one to optimise for: an empty list is not a neutral failure here,
+ * it is a school picker with nothing in it and a Get started button that cannot
+ * be pressed, so a Firestore hiccup turns into lost signups (@obaodelana on
+ * PR #42). Stale beats absent when absent means the product does not work.
+ *
+ * The disagreement is made loud instead of prevented: every fallthrough logs an
+ * error naming what happened. Nothing silently serves the catalogue.
  *
  * ## Why it is cached
  *
@@ -113,6 +121,13 @@ const cachedSchools = unstable_cache(readSchools, ["schools-list"], {
   tags: [SCHOOLS_TAG],
 });
 
+/** The seed catalogue, sorted the same way a Firestore read would be, so the
+ *  fallback and the real thing are indistinguishable to every caller except in
+ *  how fresh they are. */
+const SEEDED: School[] = [...SEED_SCHOOLS].sort(
+  (a, b) => STATUS_RANK[a.status] - STATUS_RANK[b.status] || a.name.localeCompare(b.name),
+);
+
 /**
  * Every school, cached. This is what the app should call.
  *
@@ -121,31 +136,39 @@ const cachedSchools = unstable_cache(readSchools, ["schools-list"], {
  * filtering it in memory costs less than the indexed queries the alternatives
  * would need.
  *
+ * Never returns an empty array. See the header for why stale beats absent.
+ *
  * ## The catch is OUTSIDE the cache, and that placement is the point
  *
- * `readSchools` throws rather than returning `[]`, and this function turns the
- * throw into `[]` after `unstable_cache` has already declined to store it.
+ * `readSchools` throws rather than returning a fallback, and this function
+ * handles the throw after `unstable_cache` has already declined to store it.
  * Catching one level down instead -- inside the cached function -- looks
  * identical and is a deployment hazard: `unstable_cache` stores whatever it is
- * handed, so a build machine or a cold instance that could not reach Firestore
- * for one second would bake an empty school list in for the next hour and take
- * the landing page's campus list and the whole picker with it. A thrown error
- * is not cached, so the next request simply tries again.
+ * handed, so a cold instance that could not reach Firestore for one second
+ * would pin the seeded list in place for the next hour, long after Firestore
+ * came back and started disagreeing with it. A thrown error is not cached, so
+ * the next request reads for real.
  *
- * `[]` rather than a rethrow, because this runs in the root layout: a Firestore
+ * Neither branch rethrows, because this runs in the root layout: a Firestore
  * hiccup propagating from here would take down the legal pages and the
- * dashboard along with the picker, none of which need this list to be useful.
- * The surfaces that do need it check for empty and say so.
+ * dashboard along with the picker, none of which need this list at all.
  */
 export async function listSchools(): Promise<School[]> {
   try {
-    return await cachedSchools();
+    const schools = await cachedSchools();
+    if (schools.length > 0) return schools;
+    // A successful read of an empty collection, which means nobody has run
+    // `npm run seed:schools -- --commit` against this project yet.
+    console.error(
+      "schools: the collection is empty, serving the seeded catalogue. " +
+        "Run `npm run seed:schools -- --commit` to populate it.",
+    );
   } catch (err) {
-    console.error("schools: read failed", {
+    console.error("schools: read failed, serving the seeded catalogue", {
       error: err instanceof Error ? err.message : "unknown",
     });
-    return [];
   }
+  return SEEDED;
 }
 
 /**

--- a/src/frontend/lib/schools.ts
+++ b/src/frontend/lib/schools.ts
@@ -1,0 +1,183 @@
+import "server-only";
+
+import { unstable_cache } from "next/cache";
+
+import type { School, SchoolStatus } from "@/data/schools";
+import { firestore } from "@/lib/firebaseAdmin";
+
+/**
+ * The `schools` collection, which is the source of truth for what campuses
+ * exist.
+ *
+ * Issue #36 moved this out of a TypeScript constant so that a school can be
+ * added or corrected without a deploy, and so the agent can turn the
+ * `school_id` on a user document into a real name, city, and timezone. The
+ * catalogue is seeded from scripts/schools.seed.ts by `npm run seed:schools`.
+ *
+ * ## Why there is no fallback to the seed array
+ *
+ * There deliberately is not one. A hardcoded list that stands in when Firestore
+ * is empty or unreachable is a second copy of the data that disagrees with the
+ * first, silently, on exactly the days someone is debugging why a school
+ * vanished. An empty list is a visible failure and a wrong list is not, so this
+ * returns `[]` and the surfaces above it say they could not load the schools.
+ *
+ * ## Why it is cached
+ *
+ * `readSchools` is called from the root layout, so without a cache every route
+ * in the app -- including three static legal pages -- would pay a Firestore
+ * round trip on every render. The collection changes a few times a term at
+ * most, so it is cached for an hour and tagged, and a seed run can drop the
+ * cache immediately with `revalidateTag(SCHOOLS_TAG)`.
+ */
+
+export const SCHOOLS_COLLECTION = "schools";
+
+/** Passed to `revalidateTag` to drop the cache the moment a seed run finishes,
+ *  rather than leaving a new school invisible for up to an hour. */
+export const SCHOOLS_TAG = "schools";
+
+const ONE_HOUR = 3600;
+
+/** Live first, then confirmed, then unchecked. The picker renders in list order
+ *  and a student's own school being buried under sixteen it cannot serve is the
+ *  one ordering that must not happen. */
+const STATUS_RANK: Record<SchoolStatus, number> = { live: 0, soon: 1, pending: 2 };
+
+function isStatus(value: unknown): value is SchoolStatus {
+  return value === "live" || value === "soon" || value === "pending";
+}
+
+/** Reads one document, or null if it is missing anything a caller assumes is
+ *  there. A half-written school is worse than an absent one: it reaches the
+ *  picker, gets chosen, and fails at the domain check with nothing on screen
+ *  explaining why. */
+function toSchool(snap: FirebaseFirestore.QueryDocumentSnapshot): School | null {
+  const data = snap.data();
+  const str = (key: string): string | undefined =>
+    typeof data[key] === "string" && data[key].trim() ? (data[key] as string) : undefined;
+
+  const name = str("name");
+  const province = str("province");
+  const city = str("city");
+  const timeZone = str("time_zone");
+  const emailDomain = str("email_domain");
+
+  if (!name || !province || !city || !timeZone || !emailDomain || !isStatus(data.status)) {
+    console.error("schools: skipping malformed document", { id: snap.id });
+    return null;
+  }
+
+  const rawBrand = data.brand;
+  const brand =
+    rawBrand && typeof rawBrand === "object" && typeof rawBrand.primary === "string"
+      ? {
+          primary: rawBrand.primary as string,
+          accent: typeof rawBrand.accent === "string" ? (rawBrand.accent as string) : undefined,
+          source: typeof rawBrand.source === "string" ? (rawBrand.source as string) : "",
+        }
+      : undefined;
+
+  return {
+    id: snap.id,
+    name,
+    short: str("short_name"),
+    province,
+    city,
+    timeZone,
+    emailDomain,
+    status: data.status,
+    source: str("source"),
+    note: str("note"),
+    brand,
+    logo: str("logo"),
+  };
+}
+
+/**
+ * The uncached read, which throws if Firestore will not answer.
+ *
+ * Exported for the seeder, which must see what it just wrote rather than an
+ * hour-old cache entry, and which wants a failure to be loud.
+ */
+export async function readSchools(): Promise<School[]> {
+  const snap = await firestore().collection(SCHOOLS_COLLECTION).get();
+  return snap.docs
+    .map(toSchool)
+    .filter((s): s is School => s !== null)
+    .sort((a, b) => STATUS_RANK[a.status] - STATUS_RANK[b.status] || a.name.localeCompare(b.name));
+}
+
+const cachedSchools = unstable_cache(readSchools, ["schools-list"], {
+  revalidate: ONE_HOUR,
+  tags: [SCHOOLS_TAG],
+});
+
+/**
+ * Every school, cached. This is what the app should call.
+ *
+ * Safe from a server component, a server action, or a route handler, and it is
+ * the only reader any of them need: the list is eighteen documents, so
+ * filtering it in memory costs less than the indexed queries the alternatives
+ * would need.
+ *
+ * ## The catch is OUTSIDE the cache, and that placement is the point
+ *
+ * `readSchools` throws rather than returning `[]`, and this function turns the
+ * throw into `[]` after `unstable_cache` has already declined to store it.
+ * Catching one level down instead -- inside the cached function -- looks
+ * identical and is a deployment hazard: `unstable_cache` stores whatever it is
+ * handed, so a build machine or a cold instance that could not reach Firestore
+ * for one second would bake an empty school list in for the next hour and take
+ * the landing page's campus list and the whole picker with it. A thrown error
+ * is not cached, so the next request simply tries again.
+ *
+ * `[]` rather than a rethrow, because this runs in the root layout: a Firestore
+ * hiccup propagating from here would take down the legal pages and the
+ * dashboard along with the picker, none of which need this list to be useful.
+ * The surfaces that do need it check for empty and say so.
+ */
+export async function listSchools(): Promise<School[]> {
+  try {
+    return await cachedSchools();
+  } catch (err) {
+    console.error("schools: read failed", {
+      error: err instanceof Error ? err.message : "unknown",
+    });
+    return [];
+  }
+}
+
+/**
+ * The Firestore shape, written by the seeder.
+ *
+ * Kept beside `toSchool` above for the same reason `writeNotifications` sits
+ * beside `readNotifications`: the two field-name lists are the contract, and
+ * splitting them across files is how one of them silently stops matching.
+ *
+ * Snake case, matching the `users` documents, because the agent and the Twilio
+ * functions read both and a collection that alone used camelCase would be a
+ * trap for exactly one afternoon and then a permanent irritation.
+ */
+export function writeSchool(school: School): Record<string, unknown> {
+  return {
+    id: school.id,
+    name: school.name,
+    short_name: school.short ?? null,
+    province: school.province,
+    city: school.city,
+    time_zone: school.timeZone,
+    email_domain: school.emailDomain,
+    status: school.status,
+    source: school.source ?? null,
+    note: school.note ?? null,
+    brand: school.brand
+      ? {
+          primary: school.brand.primary,
+          accent: school.brand.accent ?? null,
+          source: school.brand.source,
+        }
+      : null,
+    logo: school.logo ?? null,
+  };
+}

--- a/src/frontend/lib/timeZone.ts
+++ b/src/frontend/lib/timeZone.ts
@@ -104,7 +104,7 @@ export function resolveTimeZone(
     console.warn("timeZone: rejected an unrecognised zone", { value });
   }
 
-  // Canonicalised too. These come from scripts/schools.seed.ts, which is
+  // Canonicalised too. These come from data/schools.seed.ts, which is
   // reviewed, but a school edited in the Firestore console is not.
   const campus = schoolTimeZone ? canonicalTimeZone(schoolTimeZone) : null;
   return campus ?? FALLBACK_TIME_ZONE;

--- a/src/frontend/lib/timeZone.ts
+++ b/src/frontend/lib/timeZone.ts
@@ -1,0 +1,111 @@
+/**
+ * The student's IANA timezone: validating it, and choosing what to store when
+ * the browser will not say.
+ *
+ * ## Why this is a field of its own
+ *
+ * `time_zone` sits at the top level of the user document, beside `school_id`
+ * and `phone_number`, because issue #36 asked for it there: the agent schedules
+ * every reminder against it, and a reader that has to reach into a preferences
+ * map to find out what "9am tomorrow" means will eventually forget to.
+ *
+ * It used to live only inside the `notifications` map, and only got written if
+ * a student opened the settings page and pressed save. So the field the agent
+ * needs most was absent for every student who never visited that page, which is
+ * most of them. Onboarding writes it now.
+ *
+ * There is exactly one copy. `NotificationPrefs` reads this field rather than
+ * keeping its own, because two timezones on one document is a bug with a clock
+ * on it: they drift, and the half that loses is the one deciding whether 3am
+ * counts as quiet hours.
+ *
+ * ## Why it is validated
+ *
+ * It arrives as a hidden input on a server action, which is a public HTTP
+ * endpoint. Anything the browser sends is a claim, and this particular claim is
+ * fed to `Intl` and to whatever the agent uses to turn a local hour into an
+ * instant. An unrecognised zone is not a hostile act as often as it is an old
+ * browser, but either way storing it means storing something no reader can act
+ * on.
+ */
+
+/** The last-resort zone, and the same one `defaultNotifications` used before
+ *  this file existed. Reached only when the browser gave nothing usable AND the
+ *  student has no school on their document yet, which in practice means a
+ *  half-finished onboarding. */
+export const FALLBACK_TIME_ZONE = "America/Toronto";
+
+/**
+ * The canonical IANA spelling of a zone, or null if it is not one.
+ *
+ * Asks `Intl` rather than matching a pattern. A regex over `Region/City` admits
+ * `Foo/Bar` and rejects `UTC`, and the question that actually matters is not
+ * whether the string looks like a zone but whether the thing that will later do
+ * arithmetic with it can resolve it.
+ *
+ * ## Why it returns the resolved name rather than a boolean
+ *
+ * Because `Intl` is more forgiving than the consumer. It accepts input this
+ * field must never store:
+ *
+ *   "america/toronto"  ->  America/Toronto
+ *   "EST5EDT"          ->  America/New_York
+ *   "utc"              ->  UTC
+ *
+ * A validator that only said "yes" would have written `america/toronto`
+ * verbatim, and the agent is Python: `zoneinfo.ZoneInfo("america/toronto")`
+ * raises `ZoneInfoNotFoundError`, because the tzdata lookup is case sensitive.
+ * That is a value this side called valid and the other side cannot resolve, and
+ * it surfaces as a reminder that never fires, in a different codebase, at 3am.
+ *
+ * Reachable by hand and not just by an exotic browser: the zone arrives as a
+ * hidden input on a server action, which is a public endpoint.
+ */
+export function canonicalTimeZone(value: string): string | null {
+  if (!value) return null;
+  try {
+    // Throws RangeError on an unrecognised zone. `resolvedOptions` is what
+    // turns an accepted alias or a lowercased id into the spelling tzdata uses.
+    return new Intl.DateTimeFormat("en-CA", { timeZone: value }).resolvedOptions().timeZone;
+  } catch {
+    return null;
+  }
+}
+
+/** Whether `Intl` recognises this as a zone at all. Prefer `canonicalTimeZone`
+ *  anywhere the value is about to be stored. */
+export function isValidTimeZone(value: string): boolean {
+  return canonicalTimeZone(value) !== null;
+}
+
+/**
+ * Turns whatever the form sent into a zone worth storing.
+ *
+ * The fallback chain is deliberate, and the middle link is the useful one: a
+ * student's campus is a far better guess than a fixed default, and the two
+ * disagree by four and a half hours between Memorial and Vancouver Island. A
+ * fixed `America/Toronto` for everyone would have quietly put a UBC student's
+ * quiet hours three hours off.
+ */
+export function resolveTimeZone(
+  submitted: FormDataEntryValue | null | undefined,
+  schoolTimeZone?: string,
+): string {
+  const value = String(submitted ?? "").trim();
+
+  // The canonical spelling, never the submitted one. See canonicalTimeZone.
+  const canonical = canonicalTimeZone(value);
+  if (canonical) return canonical;
+
+  if (value) {
+    // Worth a line in the log. A browser that reports a zone `Intl` then
+    // refuses is rare enough to be interesting, and the alternative is a
+    // student silently filed under the wrong clock.
+    console.warn("timeZone: rejected an unrecognised zone", { value });
+  }
+
+  // Canonicalised too. These come from scripts/schools.seed.ts, which is
+  // reviewed, but a school edited in the Firestore console is not.
+  const campus = schoolTimeZone ? canonicalTimeZone(schoolTimeZone) : null;
+  return campus ?? FALLBACK_TIME_ZONE;
+}

--- a/src/frontend/lib/users.ts
+++ b/src/frontend/lib/users.ts
@@ -56,6 +56,10 @@ export type UserProfile = {
   name: string;
   phoneNumber: string;
   schoolId: string;
+  /** IANA zone, validated by lib/timeZone.ts before it gets here. Top level
+   *  rather than inside the notifications map, because the agent schedules
+   *  every reminder against it. See that file's header. */
+  timeZone: string;
   /** Optional second Google account for mail/Drive/Calendar. */
   serviceEmail?: string;
   consent: {
@@ -124,6 +128,7 @@ export async function upsertUser(profile: UserProfile): Promise<void> {
     email: profile.email,
     phone_number: profile.phoneNumber,
     school_id: profile.schoolId,
+    time_zone: profile.timeZone,
     service_email: profile.serviceEmail,
     consent: profile.consent,
     access: profile.access,
@@ -287,13 +292,18 @@ export async function markOnboardingComplete(userId: string): Promise<void> {
  */
 export type AccountRecord = {
   userId: string;
-  /** The nickname, or whatever onboarding fell back to. Never null once
-   *  onboarding is complete, because upsertUser defaults it to the local part
-   *  of the address. */
+  /** What the student said to call them. Required at onboarding since #36, so
+   *  it is non-null for anyone who signed up after that; accounts from before
+   *  the requirement can still have none, and the dashboard asks rather than
+   *  filling one in from the address. */
   name: string | null;
   email: string | null;
   phoneNumber: string | null;
   schoolId: string | null;
+  /** IANA zone. Null only on a document written before #36, or one whose
+   *  onboarding never finished; the settings page fills it from the browser on
+   *  the next save. */
+  timeZone: string | null;
   /** The portal login name. Not a credential: it is an identifier the school
    *  hands out, which is why it sits on this document. See recordSchoolUsername. */
   schoolUsername: string | null;
@@ -349,6 +359,7 @@ export async function getAccount(uid: string): Promise<AccountRecord | null> {
     email: typeof data.email === "string" ? data.email : null,
     phoneNumber: typeof data.phone_number === "string" ? data.phone_number : null,
     schoolId: typeof data.school_id === "string" ? data.school_id : null,
+    timeZone: typeof data.time_zone === "string" ? data.time_zone : null,
     schoolUsername: typeof data.school_username === "string" ? data.school_username : null,
     googleSub: typeof data.google_sub === "string" ? data.google_sub : null,
     googleConnected: Boolean(data.google_connected_at),
@@ -406,6 +417,19 @@ export async function updateNotificationPrefs(
  */
 export async function updateDisplayName(uid: string, name: string): Promise<void> {
   await setStamped("users", uid, { name });
+}
+
+/**
+ * Records the zone the student's browser is reporting.
+ *
+ * Written from the settings form rather than asked for, because a student who
+ * moves provinces mid-term will change their quiet hours long before it occurs
+ * to them that the zone behind those hours is now wrong. The value is validated
+ * by `resolveTimeZone` first: this is the field every reminder is scheduled
+ * against, and it arrives from a hidden input.
+ */
+export async function updateTimeZone(uid: string, timeZone: string): Promise<void> {
+  await setStamped("users", uid, { time_zone: timeZone });
 }
 
 /** Records the student's current answer on marketing email. Written beside the

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "node --import tsx --conditions=react-server --test lib/*.test.ts",
-    "verify:credentials": "node --import tsx --conditions=react-server scripts/verify-credential-write.mts"
+    "verify:credentials": "node --import tsx --conditions=react-server scripts/verify-credential-write.mts",
+    "seed:schools": "node --import tsx --conditions=react-server scripts/seed-schools.mts"
   },
   "dependencies": {
     "@google-cloud/kms": "^5.7.0",

--- a/src/frontend/scripts/schools.seed.ts
+++ b/src/frontend/scripts/schools.seed.ts
@@ -1,0 +1,203 @@
+import type { School } from "@/data/schools";
+
+/**
+ * The verified school catalogue, and the input to `npm run seed:schools`.
+ *
+ * ## This file is not read at runtime
+ *
+ * Firestore's `schools` collection is the source of truth the app reads from
+ * (lib/schools.ts). This array is what that collection is *seeded* from, which
+ * is why it lives under scripts/ rather than data/: importing it from a page
+ * would recreate the second, silently disagreeing copy that moving to Firestore
+ * was meant to remove. Nothing outside the seeder may import it.
+ *
+ * Editing a school in the Firestore console is therefore a legitimate way to
+ * change what students see, and issue #36 asked for exactly that. What it costs
+ * is the review gate below, so an edit made in the console should be brought
+ * back here in the same week, or the next seed run will quietly revert it.
+ *
+ * ## Rules for this list (see docs/design/05-schools-data.md)
+ *
+ * Classistant signs in with Google, so a school only works if its student
+ * mailbox is a Google mailbox. A school being "on Google" for Drive or Meet is
+ * not enough, the mail has to be Gmail.
+ *
+ *  - Nothing goes in as `live` without a `source` URL from the school's own IT
+ *    pages. We put institution names on a public marketing page, so a wrong
+ *    entry is a factual error about a real organisation, not a cosmetic bug.
+ *  - Platforms migrate. Re-verify every entry each August before term starts.
+ *
+ * Three statuses, and the difference between the last two matters:
+ *  - `live`    We run there today. Only these appear in marketing copy.
+ *  - `soon`    Student mail CONFIRMED on Google, with a source, but we have not
+ *              launched there. Launch scope, not a research gap.
+ *  - `pending` Not checked yet. We do not know what their mail runs on.
+ *
+ * `soon` and `pending` both read as unsupported to a student, so onboarding
+ * treats them the same. They are kept apart here because collapsing them would
+ * throw away confirmed verification work and quietly invite someone to redo it.
+ *
+ * Known NOT eligible (student mail is Microsoft 365), keep out of the list:
+ *  - Carleton University (cmail is M365)
+ *  - University of Winnipeg (self-hosted webmail)
+ *
+ * Note on Office 365: several schools hand out Office desktop apps while student
+ * MAIL still lives on Google. Availability of Office is not disqualifying, the
+ * mailbox platform is what matters.
+ *
+ * ## `city` and `timeZone`
+ *
+ * Both were added for the agent (issue #36), which knew a `school_id` and
+ * nothing else about where the student actually is. `timeZone` is the campus
+ * zone, and it is the fallback a reminder is scheduled in when a student's own
+ * `time_zone` is missing -- a wrong guess here wakes somebody up, so it is the
+ * main campus and not a guess from the province where the two disagree.
+ */
+export const SEED_SCHOOLS: School[] = [
+  // ---------------------------------------------------------------- live
+  {
+    id: "ualberta",
+    name: "University of Alberta",
+    short: "U of A",
+    province: "AB",
+    city: "Edmonton",
+    timeZone: "America/Edmonton",
+    emailDomain: "ualberta.ca",
+    status: "live",
+    source:
+      "https://www.ualberta.ca/en/information-services-and-technology/initiatives/google-workspace-changes/index.html",
+    // "Sign in with your CCID" was the first sentence here. The field it sits
+    // under now says "Student email" and prints @ualberta.ca beside the input,
+    // which answers what to type without the jargon. What is left is the part
+    // the form cannot show you.
+    note: "Google access ends when your account moves to alumni status.",
+    brand: {
+      primary: "#007C41",
+      accent: "#FFDB05",
+      source: "https://www.ualberta.ca/toolkit/visual-identity/our-colours",
+    },
+  },
+  {
+    id: "ontariotech",
+    name: "Ontario Tech University",
+    short: "Ontario Tech",
+    province: "ON",
+    city: "Oshawa",
+    timeZone: "America/Toronto",
+    emailDomain: "ontariotechu.net",
+    status: "live",
+    // Student Google Workspace is branded "OntarioTechU.Net" on their own IT
+    // pages, which is why searching for "Ontario Tech Microsoft 365" is
+    // misleading: that page is real, but it covers faculty and staff mail.
+    // Students are on Gmail.
+    source:
+      "https://itsc.ontariotechu.ca/ontariotechunet-google-apps-for-education/google-email-gmail.php",
+    note: "Undergraduates, graduates, and alumni all get an OntarioTechU.Net account.",
+    brand: {
+      primary: "#003C71",
+      accent: "#E75D2A",
+      source:
+        "https://brand.ontariotechu.ca/guidelines/brand-standards/colours-design-graphics-and-fonts/colours.php",
+    },
+  },
+
+  // ------------------------------------------------- confirmed, not launched
+  // Student mail verified on Google against the sources below. These are out of
+  // launch scope, not unverified. Flip to `live` when we open the campus.
+  {
+    id: "tmu",
+    name: "Toronto Metropolitan University",
+    short: "TMU",
+    province: "ON",
+    city: "Toronto",
+    timeZone: "America/Toronto",
+    emailDomain: "torontomu.ca",
+    status: "soon",
+    source: "https://www.torontomu.ca/google/",
+    brand: { primary: "#004C9B", source: "https://www.torontomu.ca/brand/brand-toolkit/colours/" },
+  },
+  {
+    id: "yorku",
+    name: "York University",
+    short: "York",
+    province: "ON",
+    city: "Toronto",
+    timeZone: "America/Toronto",
+    emailDomain: "my.yorku.ca",
+    status: "soon",
+    source: "https://google.info.yorku.ca/",
+    note: "Undergraduate accounts only. Graduate mail at yorku.ca is on a different platform.",
+    brand: { primary: "#E31837", source: "https://www.yorku.ca/brand/using-the-brand/colours/" },
+  },
+  {
+    id: "lakehead",
+    name: "Lakehead University",
+    short: "Lakehead",
+    province: "ON",
+    city: "Thunder Bay",
+    timeZone: "America/Toronto",
+    emailDomain: "lakeheadu.ca",
+    status: "soon",
+    source:
+      "https://www.lakeheadu.ca/faculty-and-staff/departments/services/helpdesk/email",
+    brand: {
+      primary: "#004271",
+      accent: "#FFC20E",
+      source:
+        "https://www.lakeheadu.ca/faculty-and-staff/departments/services/marketing-communications/marketing/brand-guidelines",
+    },
+  },
+  {
+    id: "mun",
+    name: "Memorial University of Newfoundland",
+    short: "Memorial",
+    province: "NL",
+    city: "St. John's",
+    // The half-hour zone, and the reason this field is not derived from
+    // `province`. Newfoundland is UTC-3:30, so anything that rounded it to
+    // Atlantic time would schedule every Memorial reminder half an hour out.
+    timeZone: "America/St_Johns",
+    emailDomain: "mun.ca",
+    status: "soon",
+    source:
+      "https://www.mun.ca/cio/it-services/communication-and-collaboration/google-workspace/",
+    note: "Access requires registration within the last three semesters.",
+    brand: {
+      primary: "#862633",
+      source:
+        "https://www.mun.ca/marcomm/media/production/memorial/administrative/marcomm/files/BrandStandards_August_2017_FA.pdf",
+    },
+  },
+  {
+    id: "mtroyal",
+    name: "Mount Royal University",
+    short: "Mount Royal",
+    province: "AB",
+    city: "Calgary",
+    timeZone: "America/Edmonton",
+    emailDomain: "mtroyal.ca",
+    status: "soon",
+    source:
+      "https://www.mtroyal.ca/CampusServices/CampusResources/InformationTechnology/EmailCalendaring/index.htm",
+    brand: {
+      primary: "#003352",
+      accent: "#007FB5",
+      source: "https://www.mtroyal.ca/AboutMountRoyal/Brand/index.htm",
+    },
+  },
+
+  // ------------------------------------------------------------- not checked
+  // Mail platform unknown. Searchable during onboarding so a student gets a real
+  // answer, never shown as supported. Confirm against the school's own IT mail
+  // page before promoting, and add the `source` in the same commit.
+  { id: "kpu", name: "Kwantlen Polytechnic University", short: "KPU", province: "BC", city: "Surrey", timeZone: "America/Vancouver", emailDomain: "student.kpu.ca", status: "pending" },
+  { id: "seneca", name: "Seneca Polytechnic", short: "Seneca", province: "ON", city: "Toronto", timeZone: "America/Toronto", emailDomain: "myseneca.ca", status: "pending" },
+  { id: "sheridan", name: "Sheridan College", short: "Sheridan", province: "ON", city: "Oakville", timeZone: "America/Toronto", emailDomain: "sheridancollege.ca", status: "pending" },
+  { id: "brock", name: "Brock University", short: "Brock", province: "ON", city: "St. Catharines", timeZone: "America/Toronto", emailDomain: "brocku.ca", status: "pending" },
+  { id: "trent", name: "Trent University", short: "Trent", province: "ON", city: "Peterborough", timeZone: "America/Toronto", emailDomain: "trentu.ca", status: "pending" },
+  { id: "nipissing", name: "Nipissing University", short: "Nipissing", province: "ON", city: "North Bay", timeZone: "America/Toronto", emailDomain: "nipissingu.ca", status: "pending" },
+  { id: "viu", name: "Vancouver Island University", short: "VIU", province: "BC", city: "Nanaimo", timeZone: "America/Vancouver", emailDomain: "viu.ca", status: "pending" },
+  { id: "tru", name: "Thompson Rivers University", short: "TRU", province: "BC", city: "Kamloops", timeZone: "America/Vancouver", emailDomain: "mytru.ca", status: "pending" },
+  { id: "smu", name: "Saint Mary's University", short: "Saint Mary's", province: "NS", city: "Halifax", timeZone: "America/Halifax", emailDomain: "smu.ca", status: "pending" },
+  { id: "cbu", name: "Cape Breton University", short: "CBU", province: "NS", city: "Sydney", timeZone: "America/Halifax", emailDomain: "cbu.ca", status: "pending" },
+];

--- a/src/frontend/scripts/seed-schools.mts
+++ b/src/frontend/scripts/seed-schools.mts
@@ -6,7 +6,7 @@
  *
  * Issue #36 made Firestore the source of truth for schools so they can be added
  * without a deploy. This is how the collection is created in the first place,
- * and how a change made in scripts/schools.seed.ts reaches it afterwards.
+ * and how a change made in data/schools.seed.ts reaches it afterwards.
  *
  * ## Three deliberate properties
  *
@@ -28,7 +28,7 @@ import { revalidateTag } from "next/cache";
 import { SCHOOLS_COLLECTION, SCHOOLS_TAG, readSchools, writeSchool } from "@/lib/schools";
 import { firestore } from "@/lib/firebaseAdmin";
 import { setStampedRef } from "@/lib/users";
-import { SEED_SCHOOLS } from "@/scripts/schools.seed";
+import { SEED_SCHOOLS } from "@/data/schools.seed";
 
 const commit = process.argv.includes("--commit");
 
@@ -63,7 +63,7 @@ if (orphans.length > 0) {
   // behind, and only a human can tell those two apart.
   console.log(
     `\n  ${orphans.length} school(s) in Firestore are not in the seed file. ` +
-      "Left untouched -- add them to scripts/schools.seed.ts, or delete them by hand:",
+      "Left untouched -- add them to data/schools.seed.ts, or delete them by hand:",
   );
   for (const school of orphans) console.log(`    orphan  ${school.id.padEnd(14)} ${school.name}`);
 }

--- a/src/frontend/scripts/seed-schools.mts
+++ b/src/frontend/scripts/seed-schools.mts
@@ -1,0 +1,98 @@
+/**
+ * Publishes the verified catalogue into the `schools` collection.
+ *
+ *   npm run seed:schools              # dry run, prints what would change
+ *   npm run seed:schools -- --commit  # actually writes
+ *
+ * Issue #36 made Firestore the source of truth for schools so they can be added
+ * without a deploy. This is how the collection is created in the first place,
+ * and how a change made in scripts/schools.seed.ts reaches it afterwards.
+ *
+ * ## Three deliberate properties
+ *
+ * **It is a dry run by default.** This is one of the few scripts in the repo
+ * meant to be pointed at the real project, so the safe direction is for a bare
+ * invocation to tell you what it would do and change nothing.
+ *
+ * **It never deletes.** A school in Firestore that is absent from the seed file
+ * is reported and left alone. Deleting would make this script the thing that
+ * silently reverts a correction somebody made in the console, which is exactly
+ * the failure the "Firestore owns it" decision was supposed to allow.
+ *
+ * **It merges, and stamps `created_at` only on insert**, through the same
+ * `setStampedRef` the user documents use. A re-seed must not reset the date a
+ * school was added.
+ */
+import { revalidateTag } from "next/cache";
+
+import { SCHOOLS_COLLECTION, SCHOOLS_TAG, readSchools, writeSchool } from "@/lib/schools";
+import { firestore } from "@/lib/firebaseAdmin";
+import { setStampedRef } from "@/lib/users";
+import { SEED_SCHOOLS } from "@/scripts/schools.seed";
+
+const commit = process.argv.includes("--commit");
+
+const target = process.env.FIRESTORE_EMULATOR_HOST
+  ? `the emulator at ${process.env.FIRESTORE_EMULATOR_HOST}`
+  : `the REAL project ${process.env.GOOGLE_CLOUD_PROJECT ?? "(GOOGLE_CLOUD_PROJECT unset)"}`;
+
+console.log(`\nseed:schools -> ${target}`);
+console.log(commit ? "mode: COMMIT, this writes\n" : "mode: dry run, nothing will be written\n");
+
+// Read before writing, so the report can say inserted vs updated rather than
+// just "wrote 18 documents", which tells you nothing about what changed.
+// `readSchools` throws rather than returning [] on a failed read, which is what
+// this wants: seeding on top of a database we could not read would report every
+// school as an insert and hide whatever is actually wrong.
+const existing = await readSchools();
+const existingIds = new Set(existing.map((s) => s.id));
+
+const inserts = SEED_SCHOOLS.filter((s) => !existingIds.has(s.id));
+const updates = SEED_SCHOOLS.filter((s) => existingIds.has(s.id));
+
+const seedIds = new Set(SEED_SCHOOLS.map((s) => s.id));
+const orphans = existing.filter((s) => !seedIds.has(s.id));
+
+for (const school of inserts) console.log(`  insert  ${school.id.padEnd(14)} ${school.name}`);
+for (const school of updates) console.log(`  update  ${school.id.padEnd(14)} ${school.name}`);
+
+if (orphans.length > 0) {
+  // Not an error. Somebody may have added a campus in the console, which is a
+  // supported way to work now. It is reported because the other possibility is
+  // a school that was renamed in the seed file and left its old document
+  // behind, and only a human can tell those two apart.
+  console.log(
+    `\n  ${orphans.length} school(s) in Firestore are not in the seed file. ` +
+      "Left untouched -- add them to scripts/schools.seed.ts, or delete them by hand:",
+  );
+  for (const school of orphans) console.log(`    orphan  ${school.id.padEnd(14)} ${school.name}`);
+}
+
+if (!commit) {
+  console.log(
+    `\n${inserts.length} insert(s), ${updates.length} update(s) pending. ` +
+      "Re-run with --commit to apply.\n",
+  );
+  process.exit(0);
+}
+
+const collection = firestore().collection(SCHOOLS_COLLECTION);
+for (const school of SEED_SCHOOLS) {
+  await setStampedRef(collection.doc(school.id), writeSchool(school));
+}
+
+console.log(`\nwrote ${SEED_SCHOOLS.length} school(s).`);
+
+// Drop the hour-long cache in lib/schools.ts, so a school added here is visible
+// on the next request instead of whenever the window happens to expire.
+// Outside a request scope this is a no-op rather than an error, which is the
+// case when the script runs against the emulator from a terminal.
+try {
+  revalidateTag(SCHOOLS_TAG);
+  console.log(`revalidated tag "${SCHOOLS_TAG}".\n`);
+} catch {
+  console.log(
+    `could not revalidate tag "${SCHOOLS_TAG}" from outside a request. ` +
+      "A deployed instance will pick the change up within the hour.\n",
+  );
+}


### PR DESCRIPTION
Closes #36. cc @obaodelana

The agent reads user documents now — [`webhook.py`](src/backend/twilio/functions/webhook.py) looks a student up by `phone_number` and hands Agent Engine a `user_id`. So the three fields in the issue stopped being display concerns and became a contract with another service. Reasoning is in [docs/design/21](docs/design/21-user-properties-and-schools.md).

## The three asks

**Name** — now a required field on the onboarding summary step, editable in the dashboard as before.

It used to default to the local part of the school address behind a "Change nickname" link. That was free while nothing read it, and became **"Hey jokafor3"** the moment Classy started greeting people.

**Not captured from Google, deliberately.** That needs the `profile` scope, and `config.py` requires its scope list stay byte-identical to `GOOGLE_SCOPES`. Adding one there breaks refresh for every grant that already exists — `google-auth` raises on `requested - granted`, silently, per student, until each reconnects. There is a safe frontend-only variant, but it buys a name the student may not want anyway at the price of inverting an invariant two files state in bold.

**`time_zone`** — top level on `users/{uid}`, IANA, captured at onboarding from the browser.

It already existed as `notifications.timezone`, but only got written if a student opened the settings page, so the field you schedule against was absent for most of them. It is validated against `Intl` and **stored canonicalised**: `Intl` accepts `america/toronto`, and `zoneinfo.ZoneInfo("america/toronto")` raises `ZoneInfoNotFoundError`, so returning the input verbatim would have handed you a value that fails at 3am in your codebase.

**`schools` collection** — `schools/{id}`, snake_case to match `users`, read at runtime via `lib/schools.ts`, seeded by `npm run seed:schools`.

Adds `city` and a per-school `time_zone` for the "full name, location etc" ask. The zone is stored per school rather than derived from the province because Newfoundland is UTC-3:30 — any two-letter mapping puts every Memorial reminder half an hour out. It is also the fallback when a student's own zone is missing.

## Two things worth a reviewer's attention

**School data left code review.** Ground rule #4 says nothing factual ships unverified, and the mechanism was that school names lived in a reviewed file. A console-editable collection gives that up. `scripts/schools.seed.ts` keeps the rules and source URLs; an edit made in the console needs bringing back there or the next seed run reverts it. The seeder never deletes — it reports orphans and leaves them.

**No fallback to the seed array.** A hardcoded list that stands in when Firestore is empty is a second copy free to disagree with the first, silently. `listSchools()` returns `[]` and the surfaces say they could not load.

## Deploying

```
npm run seed:schools              # dry run, currently 17 inserts
npm run seed:schools -- --commit  # writes
```

**Not yet run against production.** The collection is empty on `classisstant`.

An unseeded deploy is degraded but not broken: the root layout calls `connection()` when the list is empty, so it serves dynamically and re-reads rather than baking an empty hero into a static page. Worth knowing why that guard exists — the Get started CTA is gated on a school being picked, so a chipless hero has no working path into onboarding at all, and ISR would have frozen it for an hour with no way to flush it.

## Verification

`npm run typecheck` clean · `npm run build` green · tests 11/11 · seeder dry-run verified against the real project.

Reviewed the diff with a subagent, which found and I fixed: a crash in `StartNudge` dereferencing `laid[0]` on an empty list (no error boundary under `app/`, so it took the landing page down); `/dashboard/activity` left on a one-arg `readNotifications` and rendering every timestamp in Toronto; and a first pass that dropped the legacy `notifications.timezone` key, which would have reset every pre-existing account to Toronto.

## Not in scope

- The `schools` rules block is **inert** — the catch-all in `firestore.rules` still grants read/write on everything until 2026-09-21, and Firestore grants if any rule allows. That wildcard needs removing before it expires and locks the project out.
- `POST /users/{user_id}/calendar/events` still defaults `timezone` to `America/Toronto` when the caller omits it — wrong for anyone west of Ontario. Pass the student's `time_zone`.
- No backfill for accounts with no top-level `time_zone`; they read through a compatibility fallback and self-heal on their next settings save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)