### PR TITLE
Portal login moves out of onboarding; Classy can see every calendar (#49, #54)

### DIFF
--- a/docs/ENCRYPTION_CONTRACT.md
+++ b/docs/ENCRYPTION_CONTRACT.md
@@ -161,13 +161,22 @@ insert, matching the `setStamped` helper already in `lib/users.ts`.
 
 ---
 
-## 7. Scopes must stay in lockstep
+## 7. Scopes have one owner
 
-`GOOGLE_SCOPES` in `lib/googleOAuth.ts` must remain byte-identical to `scopes`
-in the connector's `src/backend/connectors-api/app/config.py` — currently
-nine entries including `drive.readonly`. Google validates the granted set
-during the exchange; a mismatch either drops permissions the agent needs or
-throws outright. Change them in the same commit, both sides.
+`GOOGLE_SCOPES` in `lib/googleOAuth.ts` is the only scope list in the system.
+The connector's `app/config.py` no longer carries one: since v0.5 it builds
+`Credentials` from a bare access token (`app/services/firestore_creds.py`) and
+never compares requested against granted scopes, so there is nothing on that
+side to drift. The earlier version of this section, which required the two to
+stay byte-identical, described a connector that has since been rewritten.
+
+`scripts/seed_credential.py` mirrors the list for local seeding and is the one
+copy to keep in step by hand. `data/access.ts` in the frontend carries a
+per-switch cross-reference for the same reason.
+
+Widening the list requires re-consent: a refresh token minted under the old set
+does not gain the new scope, and the first call needing it returns 403 until the
+student reconnects. Narrowing does not.
 
 Keep `access_type=offline` and `prompt=consent` on the consent URL. Without
 the first there is no refresh token at all; without the second a returning

--- a/docs/design/04-onboarding.md
+++ b/docs/design/04-onboarding.md
@@ -3,6 +3,13 @@
 Sources: [`app/onboarding/`](../../src/frontend/app/onboarding/),
 [`components/onboarding/`](../../src/frontend/components/onboarding/)
 
+> **Partly superseded.** The portal password step described below left
+> onboarding on 2026-09-03 (issue #54). It is asked for at `/portal-login`
+> when Classy first needs it, and [23](23-portal-login-handoff.md) has the
+> reasoning. The order of the remaining screens is number, Google, switches;
+> [15](15-firebase-auth.md) covers why the number moved to the front. The
+> rest of this document still describes the shape of the flow.
+
 ## Four screens, down from six
 
 The school is chosen in the hero and arrives as `?school=`, so onboarding starts

--- a/docs/design/07-backend-contract.md
+++ b/docs/design/07-backend-contract.md
@@ -42,9 +42,14 @@ cleanly. Put shared constants in a plain module.
 
 ### `completeOnboarding(prev, formData)`
 
+> **Superseded in part.** `portalUser` and `portalPassword` are no longer
+> fields of this action. Since #54 the portal login is collected at
+> `/portal-login` by `savePortalLogin` in `app/dashboard/actions.ts`, and the
+> password rule below applies there. See [23](23-portal-login-handoff.md).
+
 Fields: `name` (required since #36, no longer defaulted from the address),
-`timeZone` (hidden, the browser's IANA zone), `portalUser`, `portalPassword`,
-`acceptTerms`, `acceptMarketing`, `consentSms` (checkboxes are `"on"` or empty).
+`timeZone` (hidden, the browser's IANA zone), `acceptTerms`, `acceptMarketing`,
+`consentSms` (checkboxes are `"on"` or empty).
 
 The school, the address, and the number are **not** submitted. Each was proven
 by a round trip -- the SMS for the number, the Google exchange for the address

--- a/docs/design/15-firebase-auth.md
+++ b/docs/design/15-firebase-auth.md
@@ -227,7 +227,9 @@ Two layout traps this cost, both invisible in the source:
 **`SealedPasswordScene` moved to the portal step**, which resolves the concern
 [13](13-connect-scenes.md) raises about itself. The sealed envelope is a
 simplification of the Google grant and very nearly literal about the portal
-password, so it now sits on the step it is accurate on and argues for.
+password, so it now sits on the step it is accurate on and argues for. (That
+step has since left onboarding for `/portal-login`, and the scene went with it;
+see [23](23-portal-login-handoff.md).)
 
 ## Setup this depends on
 

--- a/docs/design/17-scope-narrowing.md
+++ b/docs/design/17-scope-narrowing.md
@@ -81,6 +81,14 @@ this document a lie, so it is the one to argue about in review.
 
 ## Two files, one commit
 
+> **No longer true as written.** The connector's `app/config.py` scope list is
+> gone; since contract v0.5 the service builds `Credentials` from a bare access
+> token and compares nothing, so `GOOGLE_SCOPES` is the sole owner. The
+> hand-kept mirrors are now `scripts/seed_credential.py` and the
+> cross-reference in `data/access.ts`. See [24](24-every-calendar.md), which
+> also records the one scope added since this document: the read-only
+> `calendar.calendarlist.readonly`, so Classy can see more than `primary`.
+
 `GOOGLE_SCOPES` in `src/frontend/lib/googleOAuth.ts` builds the consent URL.
 `scopes` in `src/backend/connectors-api/app/config.py` rebuilds the Credentials
 object. They are hand synced and nothing enforces it, so they change together or

--- a/docs/design/23-portal-login-handoff.md
+++ b/docs/design/23-portal-login-handoff.md
@@ -1,0 +1,178 @@
+# 23. The portal login, asked for later
+
+Onboarding no longer asks for the school portal password. The step that did is
+gone, and in its place is a page Classy texts a link to when it actually needs
+the login: `/portal-login`. This is issue #54.
+
+## What was wrong with asking during onboarding
+
+The wizard was four screens: the number, the Google grant, the portal password,
+the switches. The third one was the biggest ask in the flow and it landed at
+the worst possible moment.
+
+It is a second password, for a site the student met four minutes ago, and it
+comes before anything has been done for them. Google's consent screen at least
+looks like every other consent screen they have ever clicked through. A form on
+our page asking for the credential they use to see their grades does not, and
+the drawing beside it, however good, is us asserting our own trustworthiness
+to somebody with no evidence either way.
+
+Two costs followed. The obvious one is churn: a student who is going to bail
+on signup bails here. The less obvious one is that the ask itself reads as a
+security smell, and reasonably so. Collecting a credential up front, from
+everybody, whether or not the product ever ends up needing it for them, is the
+shape of a form that wants data more than it wants to help.
+
+## The shape now
+
+```
+onboarding    number -> Google -> switches -> done
+                                                 |
+                                                 v
+                              texts start arriving; Classy reads mail and calendar
+                                                 |
+                              Classy needs the portal for the first time
+                                                 |
+                                                 v
+                              "Add your portal login: classistant.ca/portal-login?phone=..."
+                                                 |
+                                                 v
+/portal-login   code (if signed out) -> the same form, sealed the same way -> back to Messages
+```
+
+The student is asked once, by something that has already sent them a useful
+text, with a reason attached. That is a different question from the one the
+wizard was asking, even though the fields are identical.
+
+### The onboarding wizard
+
+Three screens. `phaseForStep` maps 0 and 1 onto "Log in" and 2 onto "Welcome
+gift"; the three `PHASES` in `shell.tsx` did not change, because they were
+already counting jobs rather than screens. The Back button went with the step:
+every remaining screen either starts the flow or sits behind a proof (a
+delivered code, a completed grant) that Back could only offer to redo.
+`completeOnboarding` stopped reading `portalUser` and `portalPassword` and
+stopped calling `savePortalCredentials`, so an account can now finish onboarding
+with no portal credential at all. Every reader of the credential document
+already tolerated that; the dashboard's tile says "Missing" and links to the
+form.
+
+The done screen is the one place the portal is mentioned during signup: "When
+it needs your school portal, Classy will text you a link for that." It is the
+first moment a student has finished something and can hear "one more thing,
+later" without it costing the signup.
+
+### The page
+
+`app/portal-login/page.tsx`, rendered in the onboarding wash rather than the
+dashboard frame. It is a hand-off page a student arrives at from a text and
+leaves from, not a room they navigate around in, so the nav rail would be
+furniture for a corridor.
+
+Three states, decided below a Suspense boundary for the reason `/signin` and
+`/onboarding` put theirs there:
+
+| State | Renders |
+| --- | --- |
+| Signed out | `PhoneSignIn`, prefilled from `?phone=`, returning here |
+| Signed in, onboarding unfinished | a redirect to `/onboarding` |
+| Signed in, finished | `PortalLoginHandoff` |
+
+`PortalLoginHandoff` is the old onboarding step with its ending changed: the
+same heading ("Let it work while you sleep" names the benefit, not the
+credential), the same two fields, the same four reassurance lines, and the
+`SealedPasswordScene`, which was drawn for exactly this ask and moved with it.
+It is open by default, because the student tapped a link whose whole purpose
+is this form; the dashboard's version collapses to a button for reasons that do
+not apply here. It ends by replacing itself with a "Sealed" card whose one
+filled button is `sms:` back to Classy.
+
+The two fields are shared with the dashboard's replace form through
+`components/portal/PortalLoginFields.tsx`. That is a deliberate exception to the
+argument `PhoneSignIn` makes against sharing its fields with the wizard: there
+the fields were the only thing in common; here they are the same two names,
+read by the same server action, with the same error keys, and everything that
+differs is outside them.
+
+### The `phone` parameter proves nothing
+
+The link carries the number Classy texted so the student can skip typing it.
+That is the entire job. It is never read on the server, never compared to
+anything, and never used to decide whose account this is; identity is the SMS
+round trip, exactly as on `/signin`, and a student who is already signed in
+never sees the number field. `formatPhone` reduces whatever arrives to at most
+ten digits, so a hostile value is a wrong prefill and nothing else.
+
+`PhoneSignIn` gained `initialPhone` and `next` for this. `next` is a literal
+the page wrote, never a value from the URL: a destination read from the request
+would turn the page into an open redirect wearing a sign-in form.
+
+## The store did not change, and the issue asked whether it should
+
+The issue thread proposes something further: a `secure.classistant.ca` that
+takes the number as a parameter and keeps the encrypted details "in something
+like Cloudflare's KV for a limited time". That is a different storage model
+from the one this codebase has, and this change deliberately does not adopt
+it. The reasoning is worth recording because the proposal is not unreasonable.
+
+**What we have.** The password is envelope-encrypted under
+`classistant-password-key` and written to
+`users/{uid}/credentials/school_password`, per `docs/ENCRYPTION_CONTRACT.md`
+§1 and [19](19-portal-password-envelope.md). The frontend holds encrypt only.
+The browser agent (`src/agents/browser-agent/app/credentials.py`) is the one
+principal with decrypt, and it reads that document, by that path, with a ten
+minute in-process cache. Its `CredentialNotFound` message even says "has the
+user saved their portal password in the dashboard?".
+
+**Why not ephemeral.** The agent runs while the student is asleep. That is not
+an implementation detail, it is the product: "let it work while you sleep" is
+the heading on the form. A credential that expires minutes after being typed
+can serve the sign-in that happens right then and no other. The next overnight
+run would have to wake the student up to ask again, or the browser's cookie
+jar would have to carry every session indefinitely, which is a longer-lived
+and less protected credential than the sealed password it would be replacing.
+Persistent browser sessions per student do exist (`/mnt/cookie-storage/<uid>`,
+in the browser agent's README), and they reduce how often the password is
+replayed. They do not remove the need to hold it.
+
+**Why not Cloudflare KV specifically.** Everything in this system is on GCP:
+Firestore, KMS, Cloud Run, App Hosting, Identity Platform. A second vendor for
+one credential is a second audit story, a second failure mode and a second IAM
+model, which is precisely the situation [19](19-portal-password-envelope.md)
+records getting rid of when the password left Secret Manager. If the team does
+want a time limit, Firestore has one built in: a TTL policy on an `expires_at`
+field on the credential document, with the same envelope and the same key, and
+no new vendor.
+
+**What the frontend built is compatible with either answer.** The page collects
+two fields and calls a server action. Where that action puts the password is
+one function. If the decision goes the other way, `savePortalLogin` changes and
+the page does not.
+
+This is an open question for `@obaodelana`, not a closed one. The frontend
+half of #54 does not depend on the answer, so it shipped.
+
+## What the agent has to do
+
+Nothing here sends the link. Classy decides when it needs the portal and texts
+the URL; that is agent work and it belongs with #55's skills. The contract is:
+
+- The URL is `${NEXT_PUBLIC_APP_URL}/portal-login?phone=<E.164>`.
+- The trigger is `CredentialNotFound` from `get_portal_credentials`. That is
+  now a normal state for a finished account, not a fault.
+- After the student saves, the browser agent's ten minute credential cache may
+  still hold the miss. `clear_cache()` exists for that, or the next run picks
+  it up.
+
+Until that is wired, the dashboard's Access page and the overview tile both
+offer the form, so a student who wants to get ahead of the text can.
+
+## What is stale, and what to do about it
+
+- [04](04-onboarding.md) and [07](07-backend-contract.md) describe the portal
+  step as part of onboarding. Both carry a note pointing here.
+- The privacy policy's "information you give us during onboarding" list named
+  the portal login. It now reads "at sign-up or later" and says the credential
+  is given "when the assistant asks for them".
+- Students who onboarded before this change have a sealed password already.
+  Nothing about their account changes.

--- a/docs/design/24-every-calendar.md
+++ b/docs/design/24-every-calendar.md
@@ -1,0 +1,107 @@
+# 24. Every calendar, not just the main one
+
+Classy could only see a student's primary calendar. A student whose course
+deadlines live on a second calendar of their own, or on one a TA shares with
+the class, looked like a student with an empty term. This is issue #49, and it
+turned out to be two problems wearing one symptom.
+
+## The scope was not the whole story
+
+The issue asked for a wider Google Calendar scope. The grant already had
+`calendar.events`, which reads and writes events on *any* calendar the student
+can access, so on paper the reach was there. What it lacked is smaller and
+easier to miss: `calendar.events` cannot call `calendarList.list`. It can read
+events from a calendar whose id you already know, and it cannot tell you what
+calendars exist. So the connector's `calendar.py` did the only thing it could
+and hardcoded `calendarId="primary"` on every call.
+
+Two changes, then, and neither is sufficient alone.
+
+## The scope: one read-only line
+
+`https://www.googleapis.com/auth/calendar.calendarlist.readonly` is added to
+`GOOGLE_SCOPES`. Google's consent screen renders it as "See the list of Google
+calendars you're subscribed to". It names calendars and does nothing else.
+
+Two broader scopes would also have listed them and were not taken:
+
+| Scope | Also grants | Why not |
+| --- | --- | --- |
+| `calendar` | delete calendars, rewrite sharing | the delete-everything scope [17](17-scope-narrowing.md) removed |
+| `calendar.readonly` | read every event, settings, ACLs | none of it needed to learn a calendar exists |
+
+This keeps the rule [17](17-scope-narrowing.md) set: nothing in the grant can
+destroy a student's data beyond the calendar-events exception Google forces.
+
+## The connector: three additive changes
+
+`src/backend/connectors-api/app/routers/calendar.py`, API contract v0.7.
+
+- **`GET /calendars`** is new. Every calendar the student can at least read,
+  primary first, with `id`, `summary`, `primary` and `access_role`.
+- **`GET /events`** gains `calendar_id` (default `primary`) and `all_calendars`
+  (default `false`). With `all_calendars=true` it reads every calendar from the
+  list, merges by start time, and caps at `max_results`. Every event now
+  carries `calendar_id` and `calendar_summary`, including on the default read,
+  so a merged result stays attributable and a caller can write back to the
+  right calendar.
+- **`POST /events`** accepts `calendar_id`, default `primary`.
+
+A request that sends none of the new parameters gets the v0.6 behaviour plus
+two new fields per event. Nothing existing changed shape or name.
+
+The merge sorts on parsed datetimes rather than strings. Google returns a
+`dateTime` for timed events and a bare `date` for all-day ones, and events from
+different calendars carry different offsets, so the RFC3339 strings do not sort
+as strings. An all-day date becomes midnight UTC, which puts it ahead of the
+timed events of the same day; anything unparseable sorts last rather than
+raising.
+
+In a merged read, a calendar that was unshared between the list call and the
+events call is skipped rather than failing the whole response. Asked for by
+name, the same 403 or 404 is the caller's to hear.
+
+This half is backend work and it is in a frontend PR. It is small, additive,
+and the scope change is inert without it, so it seemed better to ship the whole
+fix and have Matthew review the Python than to ship half a fix and file a
+follow-up.
+
+## Who has to reconsent, and what they see until they do
+
+Widening the grant is the direction that needs re-consent
+([17](17-scope-narrowing.md) covers why narrowing does not). A refresh token
+minted before 2026-09-03 does not carry the new scope, and Google answers
+`calendarList.list` with 403 for it.
+
+The connector surfaces that as a 403 saying the student needs to re-consent,
+the same shape `drive.py` uses. Single-calendar reads of `primary` keep working
+on the old token, so nobody's existing deadlines disappear; only the new reach
+is gated. The Reconnect button on `/dashboard/access` is the way through, and
+because `buildAuthUrl` sets `prompt=consent`, pressing it shows the full
+consent screen again with the new line on it.
+
+## The sync rule changed underneath this
+
+`googleOAuth.ts`, [12](12-onboarding-persistence.md), [17](17-scope-narrowing.md)
+and `ENCRYPTION_CONTRACT.md` §7 all said `GOOGLE_SCOPES` had to stay
+byte-identical to a `scopes` list in the connector's `app/config.py`, because
+the connector rebuilt a `Credentials` object from its own copy and google-auth
+compared the two sets.
+
+That list does not exist any more. Since contract v0.5 the connector builds
+`Credentials` from a bare access token (`app/services/firestore_creds.py`) and
+compares nothing, so the frontend is the sole owner of the scope list and there
+is nothing on the connector side to drift. The comments and §7 now say so. Two
+hand-kept mirrors remain and were updated here:
+
+- `scripts/seed_credential.py` in the connector, which had drifted badly: it
+  still asked for the full `calendar` scope and for `drive.file`, both of which
+  [17](17-scope-narrowing.md) removed, so a token seeded from it could do things
+  a real student's token cannot.
+- The `scopes` cross-reference on the calendar row of `data/access.ts`.
+
+## One thing still to do outside the repo
+
+If the OAuth app is ever verified, the new scope has to be declared on the
+consent screen in the Cloud Console. In testing mode, which is where the app
+is, any scope works for test users and nothing needs changing there.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -29,6 +29,8 @@ Read these before changing something that looks arbitrary. Most of it is not.
 | [20 The signed-in area](20-dashboard.md) | The four dashboard pages, the second front door at /signin, the two kinds of promise a control can make, and why the task history is empty |
 | [21 User properties and schools](21-user-properties-and-schools.md) | The three fields the agent reads, why the name is asked for rather than taken from Google, and the schools collection |
 | [22 Texting Classy](22-text-classy.md) | The number on the done screen, why it is typeset rather than buried in a button, no prefilled body, and the three places the number is hand-synced |
+| [23 Portal login hand-off](23-portal-login-handoff.md) | Why the portal password left onboarding, the page Classy texts instead, what the phone param does and does not prove, and why the store stayed sealed rather than going ephemeral |
+| [24 Every calendar](24-every-calendar.md) | Why Classy only saw the primary calendar, the one read-only scope that fixes it, the connector half, who has to reconnect, and the sync rule that quietly expired |
 
 ## Ground rules that apply everywhere
 

--- a/src/backend/connectors-api/API_CONTRACT.md
+++ b/src/backend/connectors-api/API_CONTRACT.md
@@ -1,4 +1,4 @@
-# Classistant AI Connector API — Contract v0.6 (handoff for ADK tools)
+# Classistant AI Connector API — Contract v0.7 (handoff for ADK tools)
 
 Base URL: `https://<cloud-run-url>` (local: `http://localhost:8080`). All responses JSON.
 `{user_id}` in every path below is the **Firebase UID** — the same identifier the frontend's session already carries and the `users` collection is keyed by. There is no other identifier this service accepts; a Google `sub` is never a valid `{user_id}`.
@@ -19,8 +19,9 @@ This service has no auth endpoints. Login, the OAuth authorization-code exchange
 ## Calendar
 | Method | Path | In | Out |
 |---|---|---|---|
-| GET | `/users/{user_id}/calendar/events?time_min&time_max&max_results` | RFC3339 times | `{events:[{id, summary, description, start, end, location, html_link}], count}` (P1) |
-| POST | `/users/{user_id}/calendar/events` | `{summary, start, end, description?, location?, timezone?}` | `{event_id, html_link, status:"created"}` (P1) |
+| GET | `/users/{user_id}/calendar/calendars` | — | `{calendars:[{id, summary, primary, access_role}], count}` — every calendar the student can read, primary first. `403` when the grant predates the `calendar.calendarlist.readonly` scope; the student reconnects from the frontend's `/dashboard/access` (v0.7) |
+| GET | `/users/{user_id}/calendar/events?time_min&time_max&max_results&calendar_id=primary&all_calendars=false` | RFC3339 times. `calendar_id` is an id from `/calendars`, default `primary`. `all_calendars=true` reads every readable calendar, merges by start, caps at `max_results`, and ignores `calendar_id` | `{events:[{id, summary, description, start, end, location, html_link, calendar_id, calendar_summary}], count}` (P1) |
+| POST | `/users/{user_id}/calendar/events` | `{summary, start, end, description?, location?, timezone?, calendar_id?}` — `calendar_id` defaults to `primary`; `403` if the student cannot write to the one named | `{event_id, html_link, status:"created"}` (P1) |
 
 ## Drive / Docs (P2)
 | Method | Path | In | Out |
@@ -66,3 +67,4 @@ Every `/users/{user_id}/...` endpoint reads through `app/services/firestore_cred
 - v0.4 (**breaking**): `/auth/login` and `/auth/callback` removed — login moved to the frontend (issue #12). `{user_id}` in path params is now a Firebase UID, not a Google `sub`. Credential storage moved from Secret Manager to Firestore + KMS envelope encryption; new `500` error semantics for malformed stored credentials (see Errors).
 - v0.5 (**breaking**): corrects a false start within this same version — `/auth/callback` was briefly restored (client secret handling was mistakenly believed to require it) and then removed again for good once [`docs/ENCRYPTION_CONTRACT.md`](../../../docs/ENCRYPTION_CONTRACT.md) settled the frontend as owning the full write side, encrypt included. This service now has **zero** auth endpoints, **zero** KMS encrypt capability, and no code path that can name or touch a `school_password` credential. The `google_sub` fallback lookup on the read path is also removed — `{user_id}` is the Firebase UID with no alternate-identifier tolerance, anywhere. Credential documents are now read from `users/{user_id}/credentials/google_refresh_token` (a direct document get) rather than a queried top-level `user_credentials` collection.
 - v0.6: `POST /docs` accepts an optional `markdown` flag (default `false`), and its response gains `formatting_applied` (default `true`). Both are **additive** — no existing field changed shape or name, and `markdown: false` sends byte-for-byte the request v0.5 sent. `formatting_applied` is a declared field on `DocCreatedResponse`, so it survives the endpoint's `response_model` filtering.
+- v0.7: Calendar reaches past `primary` (issue #49). New `GET /calendar/calendars`. `GET /calendar/events` gains `calendar_id` and `all_calendars`, and every event now carries `calendar_id` and `calendar_summary`. `POST /calendar/events` accepts `calendar_id`. All **additive**: a request with none of the new params gets the v0.6 behaviour plus two new fields per event. Depends on the `calendar.calendarlist.readonly` scope, added to the frontend's `GOOGLE_SCOPES` in the same change — **re-consent required** for anyone who granted before it; until they do, `/calendars` and `all_calendars=true` return `403` and the single-calendar reads keep working. See `docs/design/24-every-calendar.md`.

--- a/src/backend/connectors-api/app/routers/calendar.py
+++ b/src/backend/connectors-api/app/routers/calendar.py
@@ -1,11 +1,40 @@
-"""Google Calendar connector (P1: list events, create events)."""
+"""Google Calendar connector (P1: list calendars, list events, create events).
+
+Every read and write used to be pinned to ``calendarId="primary"``. That was
+not a choice so much as the only thing the grant allowed: ``calendar.events``
+can read and write events on any calendar the student can reach, but it cannot
+*list* those calendars, so there was no way to learn a second one existed. A
+student whose course deadlines live on a "School" calendar, or on one a TA
+shares with the class, looked to Classy like a student with an empty term
+(issue #49).
+
+The frontend now also requests ``calendar.calendarlist.readonly`` -- the one
+read-only scope that names calendars and touches nothing else -- and this
+router uses it: ``GET /calendars`` lists them, ``GET /events`` can read one by
+id or all of them merged, and ``POST /events`` can write to one by id. Every
+default is still ``primary``, so a caller that sends nothing new gets exactly
+what it got before.
+
+Tokens granted before that scope was added cannot list calendars. Google
+answers ``calendarList.list`` with 403 for them, which is surfaced here as a
+403 telling the caller the student has to reconnect (the frontend's
+/dashboard/access has the button). See docs/design/24-every-calendar.md.
+"""
 from datetime import datetime, timezone
-from fastapi import APIRouter, Query
+
+from fastapi import APIRouter, HTTPException, Query
+from googleapiclient.errors import HttpError
 from pydantic import BaseModel, Field
 
 from app.services.google_creds import service_for_user
 
 router = APIRouter(prefix="/users/{user_id}/calendar", tags=["calendar"])
+
+# Same shape as drive.py's 403, and the same meaning: the scope set the token
+# was minted under is older than the one the code needs.
+_RECONSENT = (
+    "No access to the calendar list — user may need to re-consent with updated scopes"
+)
 
 
 class EventStartEnd(BaseModel):
@@ -28,6 +57,13 @@ class CalendarEvent(BaseModel):
     location: str | None = None
     html_link: str | None = Field(
         None, alias="htmlLink", description="Link to the event in Calendar UI.")
+    # Which calendar this came from. Always set, including for `primary`, so a
+    # merged read across calendars stays attributable and a caller can write
+    # back to the right one.
+    calendar_id: str | None = Field(
+        None, description="Id of the calendar the event lives on.")
+    calendar_summary: str | None = Field(
+        None, description="That calendar's display name, when known.")
 
     model_config = {"populate_by_name": True}
 
@@ -37,24 +73,139 @@ class EventListResponse(BaseModel):
     count: int
 
 
+class CalendarSummary(BaseModel):
+    id: str
+    summary: str | None = None
+    primary: bool = False
+    # No alias, on purpose. FastAPI serialises response models by alias, so an
+    # `accessRole` alias here would put Google's camelCase into our JSON where
+    # the contract promises `access_role`. The rename happens in `_summary`.
+    access_role: str | None = Field(
+        None, description="reader | writer | owner. Only writer and owner can take a POST.")
+
+
+def _summary(c: dict) -> "CalendarSummary":
+    return CalendarSummary(
+        id=c["id"],
+        summary=c.get("summary"),
+        primary=bool(c.get("primary", False)),
+        access_role=c.get("accessRole"),
+    )
+
+
+class CalendarListResponse(BaseModel):
+    calendars: list[CalendarSummary]
+    count: int
+
+
+def _list_calendars(svc) -> list[dict]:
+    """Every calendar the student can at least read, primary first, then by name.
+
+    Raises 403 when the token predates the calendarlist scope; that is the only
+    error this call produces in practice, and it is the student's to fix.
+    """
+    items: list[dict] = []
+    page_token = None
+    try:
+        while True:
+            resp = svc.calendarList().list(
+                minAccessRole="reader", pageToken=page_token).execute()
+            items.extend(resp.get("items", []))
+            page_token = resp.get("nextPageToken")
+            if not page_token:
+                break
+    except HttpError as e:
+        if e.resp.status == 403:
+            raise HTTPException(403, _RECONSENT)
+        raise
+    items.sort(key=lambda c: (not c.get("primary", False), (c.get("summary") or "").lower()))
+    return items
+
+
+def _start_key(ev: CalendarEvent) -> datetime:
+    """A comparable start for merging across calendars.
+
+    Google gives a dateTime for timed events and a bare date for all-day ones,
+    and events from different calendars carry different offsets, so the strings
+    cannot be sorted as strings. Everything is parsed to an aware datetime; an
+    all-day date becomes midnight UTC, which puts it ahead of the timed events
+    of the same day, and anything unparseable sorts last rather than raising.
+    """
+    raw = (ev.start.date_time or ev.start.date) if ev.start else None
+    if not raw:
+        return datetime.max.replace(tzinfo=timezone.utc)
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return datetime.max.replace(tzinfo=timezone.utc)
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+@router.get("/calendars", response_model=CalendarListResponse)
+def list_calendars(user_id: str):
+    """List every calendar on the student's account: their own, plus any shared with them (a course calendar, a TA's office hours). Primary first."""
+    svc = service_for_user(user_id, "calendar", "v3")
+    items = _list_calendars(svc)
+    return CalendarListResponse(calendars=[_summary(c) for c in items], count=len(items))
+
+
 @router.get("/events", response_model=EventListResponse)
 def list_events(
     user_id: str,
     time_min: str | None = Query(None, description="RFC3339, defaults to now"),
     time_max: str | None = Query(None, description="RFC3339"),
     max_results: int = Query(25, le=100),
+    calendar_id: str = Query(
+        "primary",
+        description="Which calendar to read: an id from GET /calendars, or `primary`. "
+                    "Ignored when all_calendars is true."),
+    all_calendars: bool = Query(
+        False,
+        description="Read every calendar the student can see and merge the results, "
+                    "sorted by start and capped at max_results."),
 ):
-    """List upcoming primary-calendar events, expanding recurring series into individual instances sorted by start time."""
+    """List upcoming events, expanding recurring series into individual instances sorted by start time. Reads the primary calendar unless `calendar_id` names another or `all_calendars` is set."""
     svc = service_for_user(user_id, "calendar", "v3")
-    resp = svc.events().list(
-        calendarId="primary",
-        timeMin=time_min or datetime.now(timezone.utc).isoformat(),
-        timeMax=time_max,
-        maxResults=max_results,
-        singleEvents=True,
-        orderBy="startTime",
-    ).execute()
-    events = [CalendarEvent.model_validate(e) for e in resp.get("items", [])]
+    time_min = time_min or datetime.now(timezone.utc).isoformat()
+
+    if all_calendars:
+        calendars = [(c["id"], c.get("summary")) for c in _list_calendars(svc)]
+    else:
+        calendars = [(calendar_id, None)]
+
+    events: list[CalendarEvent] = []
+    for cid, summary in calendars:
+        try:
+            resp = svc.events().list(
+                calendarId=cid,
+                timeMin=time_min,
+                timeMax=time_max,
+                maxResults=max_results,
+                singleEvents=True,
+                orderBy="startTime",
+            ).execute()
+        except HttpError as e:
+            # In a merged read, a calendar that was unshared between the list
+            # call and this one is not worth failing the whole response for.
+            # Asked for by name, the same errors are the caller's to hear.
+            if all_calendars and e.resp.status in (403, 404):
+                continue
+            if e.resp.status == 404:
+                raise HTTPException(404, f"Calendar {cid} not found")
+            if e.resp.status == 403:
+                raise HTTPException(
+                    403, "No access to this calendar — user may need to re-consent with updated scopes")
+            raise
+        # events.list returns the calendar's own title as `summary` on the
+        # response, which is what fills the name in for a single-calendar read.
+        calendar_summary = summary or resp.get("summary")
+        for item in resp.get("items", []):
+            events.append(CalendarEvent.model_validate(
+                {**item, "calendar_id": cid, "calendar_summary": calendar_summary}))
+
+    if all_calendars:
+        events.sort(key=_start_key)
+        events = events[:max_results]
     return EventListResponse(events=events, count=len(events))
 
 
@@ -65,6 +216,9 @@ class EventIn(BaseModel):
     description: str | None = None
     location: str | None = None
     timezone: str = "America/Toronto"
+    # Where to write it. `primary` unless the caller has a reason, and a reason
+    # is an id from GET /calendars with access_role writer or owner.
+    calendar_id: str = "primary"
 
 
 class EventCreatedResponse(BaseModel):
@@ -76,7 +230,7 @@ class EventCreatedResponse(BaseModel):
 
 @router.post("/events", status_code=201, response_model=EventCreatedResponse)
 def create_event(user_id: str, event: EventIn):
-    """Create a new event on the user's primary calendar (e.g. a syllabus deadline or exam date)."""
+    """Create a new event (e.g. a syllabus deadline or exam date) on the user's primary calendar, or on the calendar named by `calendar_id`."""
     svc = service_for_user(user_id, "calendar", "v3")
     body = {
         "summary": event.summary,
@@ -85,5 +239,13 @@ def create_event(user_id: str, event: EventIn):
         "start": {"dateTime": event.start, "timeZone": event.timezone},
         "end": {"dateTime": event.end, "timeZone": event.timezone},
     }
-    created = svc.events().insert(calendarId="primary", body=body).execute()
+    try:
+        created = svc.events().insert(calendarId=event.calendar_id, body=body).execute()
+    except HttpError as e:
+        if e.resp.status == 404:
+            raise HTTPException(404, f"Calendar {event.calendar_id} not found")
+        if e.resp.status == 403:
+            raise HTTPException(
+                403, "No write access to this calendar — pick one with access_role writer or owner")
+        raise
     return EventCreatedResponse(event_id=created["id"], html_link=created.get("htmlLink"))

--- a/src/backend/connectors-api/scripts/seed_credential.py
+++ b/src/backend/connectors-api/scripts/seed_credential.py
@@ -48,18 +48,24 @@ KMS_KEYRING = "classistant-keyring"
 KMS_KEY = "classistant-key"          # refresh-token key, NOT the password key
 CREDENTIAL_TYPE = "google_refresh_token"
 
-# Must stay byte-identical to GOOGLE_SCOPES in the frontend's lib/googleOAuth.ts
-# and to `scopes` in app/config.py.
+# A mirror of GOOGLE_SCOPES in the frontend's lib/googleOAuth.ts, which is the
+# owner. app/config.py no longer carries a scope list (the service builds
+# Credentials from a bare access token and compares nothing), so this is the
+# only copy on this side and it is kept in step by hand. It had drifted: it
+# still asked for the full `calendar` scope and for `drive.file`, both of which
+# docs/design/17 removed from the real grant, so a token seeded from here could
+# do things a real student's token cannot.
 SCOPES = [
     "openid",
     "https://www.googleapis.com/auth/userinfo.email",
     "https://www.googleapis.com/auth/gmail.readonly",
     "https://www.googleapis.com/auth/gmail.compose",
-    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.events.owned",
+    "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
     "https://www.googleapis.com/auth/drive.metadata.readonly",
     "https://www.googleapis.com/auth/drive.readonly",
     "https://www.googleapis.com/auth/documents",
-    "https://www.googleapis.com/auth/drive.file",
 ]
 
 

--- a/src/backend/connectors-api/tests/test_calendar_router.py
+++ b/src/backend/connectors-api/tests/test_calendar_router.py
@@ -1,0 +1,317 @@
+"""Tests for the /users/{user_id}/calendar endpoints.
+
+Same approach as test_docs_router.py: the Google client is swapped for a
+recorder, so these assert the exact calendarId and parameters that would go
+over the wire rather than mocking the thing under test.
+
+The load-bearing test is `test_default_read_is_primary_only`. The agent is
+already calling GET /events with none of the v0.7 parameters, and that request
+has to keep reading `primary` and must never touch calendarList, which a token
+granted before the calendarlist scope cannot call.
+"""
+import json
+
+import httplib2
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from googleapiclient.errors import HttpError
+
+import app.routers.calendar as calendar
+
+USER = "firebase-uid-1"
+BASE = f"/users/{USER}/calendar"
+
+PRIMARY = {"id": "primary-id", "summary": "Me", "primary": True, "accessRole": "owner"}
+COURSE = {"id": "course-id", "summary": "COMP 250", "accessRole": "reader"}
+CLUB = {"id": "club-id", "summary": "Chess", "accessRole": "writer"}
+
+
+def http_error(status: int) -> HttpError:
+    resp = httplib2.Response({"status": status, "reason": "x"})
+    return HttpError(resp, json.dumps({"error": {"message": "x"}}).encode())
+
+
+def event(event_id: str, *, date_time: str | None = None, date: str | None = None) -> dict:
+    start = {"dateTime": date_time} if date_time else {"date": date}
+    return {"id": event_id, "summary": event_id, "start": start, "end": start}
+
+
+# Three calendars. Chosen so the merged order is not the per-calendar order and
+# not the string order of the raw start values:
+#   c2  all-day 2026-09-10           -> 2026-09-10T00:00Z
+#   c1  2026-09-09T23:30:00-04:00    -> 2026-09-10T03:30Z
+#   p1  2026-09-10T09:00:00-04:00    -> 2026-09-10T13:00Z
+#   k1  2026-09-11T08:00:00+01:00    -> 2026-09-11T07:00Z
+EVENTS = {
+    "primary": {"summary": "Me", "items": [event("p1", date_time="2026-09-10T09:00:00-04:00")]},
+    "primary-id": {"summary": "Me", "items": [event("p1", date_time="2026-09-10T09:00:00-04:00")]},
+    "course-id": {
+        "summary": "COMP 250",
+        "items": [
+            event("c1", date_time="2026-09-09T23:30:00-04:00"),
+            event("c2", date="2026-09-10"),
+        ],
+    },
+    "club-id": {"summary": "Chess", "items": [event("k1", date_time="2026-09-11T08:00:00+01:00")]},
+}
+
+
+class _Executable:
+    def __init__(self, result=None, error=None):
+        self._result, self._error = result, error
+
+    def execute(self):
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+class _FakeCalendarList:
+    def __init__(self, calls, calendars, error):
+        self.calls, self.calendars, self.error = calls, calendars, error
+
+    def list(self, **kwargs):
+        self.calls.append(("calendarList.list", kwargs))
+        if self.error is not None:
+            return _Executable(error=self.error)
+        return _Executable({"items": self.calendars})
+
+
+class _FakeEvents:
+    def __init__(self, calls, event_errors, insert_error):
+        self.calls, self.event_errors, self.insert_error = calls, event_errors, insert_error
+
+    def list(self, **kwargs):
+        self.calls.append(("events.list", kwargs))
+        cid = kwargs["calendarId"]
+        if cid in self.event_errors:
+            return _Executable(error=self.event_errors[cid])
+        cal = EVENTS.get(cid)
+        if cal is None:
+            return _Executable(error=http_error(404))
+        return _Executable({"summary": cal["summary"], "items": cal["items"]})
+
+    def insert(self, **kwargs):
+        self.calls.append(("events.insert", kwargs))
+        if self.insert_error is not None:
+            return _Executable(error=self.insert_error)
+        return _Executable({"id": "evt-new", "htmlLink": "https://calendar.google.com/evt-new"})
+
+
+class _FakeService:
+    def __init__(self, calls, calendars, list_error, event_errors, insert_error):
+        self._cl = _FakeCalendarList(calls, calendars, list_error)
+        self._ev = _FakeEvents(calls, event_errors, insert_error)
+
+    def calendarList(self):  # noqa: N802 -- Google's method name
+        return self._cl
+
+    def events(self):
+        return self._ev
+
+
+@pytest.fixture
+def install(monkeypatch):
+    """Installs a fake Google client and returns the list it records into."""
+    def _install(
+        calendars=(CLUB, COURSE, PRIMARY),
+        list_error=None,
+        event_errors=None,
+        insert_error=None,
+    ):
+        recorded = []
+        monkeypatch.setattr(
+            calendar,
+            "service_for_user",
+            lambda user_id, api, version: _FakeService(
+                recorded, list(calendars), list_error, event_errors or {}, insert_error),
+        )
+        return recorded
+    return _install
+
+
+@pytest.fixture
+def client():
+    api = FastAPI()
+    api.include_router(calendar.router)
+    return TestClient(api)
+
+
+def calls_named(calls, name):
+    return [c for c in calls if c[0] == name]
+
+
+# --------------------------------------------------------------------------
+# GET /events, unchanged defaults
+# --------------------------------------------------------------------------
+
+def test_default_read_is_primary_only(client, install):
+    calls = install()
+
+    r = client.get(f"{BASE}/events")
+
+    assert r.status_code == 200
+    assert calls_named(calls, "calendarList.list") == [], "a default read must not need the new scope"
+    lists = calls_named(calls, "events.list")
+    assert len(lists) == 1
+    assert lists[0][1]["calendarId"] == "primary"
+    assert lists[0][1]["singleEvents"] is True
+    assert lists[0][1]["orderBy"] == "startTime"
+
+    body = r.json()
+    assert body["count"] == 1
+    assert body["events"][0]["id"] == "p1"
+    # The two new fields are the only difference from v0.6 on a default read.
+    assert body["events"][0]["calendar_id"] == "primary"
+    assert body["events"][0]["calendar_summary"] == "Me"
+
+
+def test_calendar_id_reads_that_calendar(client, install):
+    calls = install()
+
+    r = client.get(f"{BASE}/events", params={"calendar_id": "course-id"})
+
+    assert r.status_code == 200
+    assert calls_named(calls, "events.list")[0][1]["calendarId"] == "course-id"
+    assert {e["calendar_summary"] for e in r.json()["events"]} == {"COMP 250"}
+
+
+def test_named_calendar_that_does_not_exist_is_404(client, install):
+    install()
+    r = client.get(f"{BASE}/events", params={"calendar_id": "nope"})
+    assert r.status_code == 404
+
+
+def test_named_calendar_403_asks_for_reconsent(client, install):
+    install(event_errors={"course-id": http_error(403)})
+    r = client.get(f"{BASE}/events", params={"calendar_id": "course-id"})
+    assert r.status_code == 403
+    assert "re-consent" in r.json()["detail"]
+
+
+# --------------------------------------------------------------------------
+# GET /calendars
+# --------------------------------------------------------------------------
+
+def test_list_calendars_primary_first_then_by_name(client, install):
+    calls = install(calendars=(CLUB, COURSE, PRIMARY))
+
+    r = client.get(f"{BASE}/calendars")
+
+    assert r.status_code == 200
+    assert calls_named(calls, "calendarList.list")[0][1]["minAccessRole"] == "reader"
+    body = r.json()
+    assert body["count"] == 3
+    assert [c["id"] for c in body["calendars"]] == ["primary-id", "club-id", "course-id"]
+    assert body["calendars"][0]["primary"] is True
+    assert body["calendars"][1]["access_role"] == "writer"
+
+
+def test_list_calendars_403_means_the_token_predates_the_scope(client, install):
+    install(list_error=http_error(403))
+    r = client.get(f"{BASE}/calendars")
+    assert r.status_code == 403
+    assert "re-consent" in r.json()["detail"]
+
+
+# --------------------------------------------------------------------------
+# GET /events?all_calendars=true
+# --------------------------------------------------------------------------
+
+def test_all_calendars_merges_across_offsets_and_caps(client, install):
+    calls = install()
+
+    r = client.get(f"{BASE}/events", params={"all_calendars": "true", "max_results": 3})
+
+    assert r.status_code == 200
+    assert len(calls_named(calls, "calendarList.list")) == 1
+    assert {c[1]["calendarId"] for c in calls_named(calls, "events.list")} == {
+        "primary-id", "course-id", "club-id"}
+
+    body = r.json()
+    # Four events exist; capped at three, in true chronological order rather
+    # than per-calendar or string order (see the table above EVENTS).
+    assert body["count"] == 3
+    assert [e["id"] for e in body["events"]] == ["c2", "c1", "p1"]
+    assert body["events"][0]["calendar_summary"] == "COMP 250"
+    assert body["events"][2]["calendar_id"] == "primary-id"
+
+
+def test_all_calendars_ignores_calendar_id(client, install):
+    calls = install()
+    client.get(f"{BASE}/events", params={"all_calendars": "true", "calendar_id": "nope"})
+    assert "nope" not in {c[1]["calendarId"] for c in calls_named(calls, "events.list")}
+
+
+def test_all_calendars_skips_a_calendar_that_was_unshared(client, install):
+    install(event_errors={"club-id": http_error(403)})
+
+    r = client.get(f"{BASE}/events", params={"all_calendars": "true"})
+
+    assert r.status_code == 200
+    ids = [e["id"] for e in r.json()["events"]]
+    assert "k1" not in ids
+    assert set(ids) == {"c2", "c1", "p1"}
+
+
+def test_all_calendars_403_on_the_list_is_reconsent(client, install):
+    install(list_error=http_error(403))
+    r = client.get(f"{BASE}/events", params={"all_calendars": "true"})
+    assert r.status_code == 403
+
+
+# --------------------------------------------------------------------------
+# POST /events
+# --------------------------------------------------------------------------
+
+BODY = {"summary": "Midterm", "start": "2026-10-01T09:00:00-04:00", "end": "2026-10-01T11:00:00-04:00"}
+
+
+def test_create_event_defaults_to_primary(client, install):
+    calls = install()
+
+    r = client.post(f"{BASE}/events", json=BODY)
+
+    assert r.status_code == 201
+    insert = calls_named(calls, "events.insert")[0][1]
+    assert insert["calendarId"] == "primary"
+    assert insert["body"]["summary"] == "Midterm"
+    assert r.json() == {
+        "event_id": "evt-new",
+        "html_link": "https://calendar.google.com/evt-new",
+        "status": "created",
+    }
+
+
+def test_create_event_on_a_named_calendar(client, install):
+    calls = install()
+    r = client.post(f"{BASE}/events", json={**BODY, "calendar_id": "club-id"})
+    assert r.status_code == 201
+    assert calls_named(calls, "events.insert")[0][1]["calendarId"] == "club-id"
+
+
+def test_create_event_on_a_read_only_calendar_is_403(client, install):
+    install(insert_error=http_error(403))
+    r = client.post(f"{BASE}/events", json={**BODY, "calendar_id": "course-id"})
+    assert r.status_code == 403
+    assert "writer or owner" in r.json()["detail"]
+
+
+# --------------------------------------------------------------------------
+# The merge key on its own
+# --------------------------------------------------------------------------
+
+def test_start_key_orders_all_day_before_timed_and_unparseable_last():
+    def ev(**start):
+        return calendar.CalendarEvent(id="x", start=calendar.EventStartEnd(**start))
+
+    all_day = ev(date="2026-09-10")
+    early = ev(date_time="2026-09-09T23:30:00-04:00")   # 03:30Z on the 10th
+    zulu = ev(date_time="2026-09-10T13:00:00Z")
+    broken = ev(date_time="not a date")
+    none = calendar.CalendarEvent(id="x")
+
+    ordered = sorted([broken, zulu, none, early, all_day], key=calendar._start_key)
+    assert ordered[:3] == [all_day, early, zulu]
+    assert set(map(id, ordered[3:])) == {id(broken), id(none)}

--- a/src/frontend/app/api/auth/session/route.ts
+++ b/src/frontend/app/api/auth/session/route.ts
@@ -68,7 +68,7 @@ export async function POST(request: NextRequest) {
     // Added for /signin, which has to choose between the dashboard and the rest
     // of onboarding and cannot tell them apart from `connected` alone: a
     // student can have completed the Google grant and then abandoned the flow
-    // before the portal password, which leaves `connected` true and the account
+    // before the last step, which leaves `connected` true and the account
     // unfinished. The wizard ignores this field; it decides its opening step
     // from `connected`, which is the right question for it to be asking.
     onboardingComplete: record?.onboardingComplete ?? false,

--- a/src/frontend/app/dashboard/layout.tsx
+++ b/src/frontend/app/dashboard/layout.tsx
@@ -41,8 +41,8 @@ export const dynamic = "force-dynamic";
  *
  * Signed in but unfinished goes to /onboarding, and that is the case worth
  * naming: a student who verified a number and closed the tab holds a perfectly
- * valid session and an account with no school, no Google grant, and no portal
- * password. Every card on every page here would be empty, and several of the
+ * valid session and an account with no school, no Google grant, and no
+ * consents. Every card on every page here would be empty, and several of the
  * controls would be writing preferences onto an account that does not do
  * anything yet. Sending them back to the flow that fills it is both the more
  * useful answer and the one that keeps the pages below from needing a "what if

--- a/src/frontend/app/dashboard/page.tsx
+++ b/src/frontend/app/dashboard/page.tsx
@@ -115,10 +115,13 @@ export default async function OverviewPage() {
           note={
             portalSealed
               ? "Your password is encrypted under a key we can lock and cannot open."
-              : "Without it, Classistant cannot check your portal overnight."
+              : "Without it, Classistant cannot check your portal overnight. Classy will text you a link when it needs it, or add it now."
           }
           href="/dashboard/access"
-          hrefLabel="Replace it"
+          // "Missing" is the normal state for a new account now, not a broken
+          // one: onboarding stopped asking for the portal login (#54), so this
+          // tile is where a student who wants to get ahead of the text can.
+          hrefLabel={portalSealed ? "Replace it" : "Add it"}
         />
 
         <Tile

--- a/src/frontend/app/onboarding/actions.ts
+++ b/src/frontend/app/onboarding/actions.ts
@@ -9,7 +9,6 @@ import { getSession } from "@/lib/authSession";
 import { FieldValue } from "@/lib/firebaseAdmin";
 import { buildAuthUrl, randomState } from "@/lib/googleOAuth";
 import { setPendingOAuth } from "@/lib/onboardingSession";
-import { savePortalCredentials } from "@/lib/portalCredentials";
 import { listSchools } from "@/lib/schools";
 import { resolveTimeZone } from "@/lib/timeZone";
 import { getUser, markOnboardingComplete, upsertUser } from "@/lib/users";
@@ -18,14 +17,19 @@ import { getUser, markOnboardingComplete, upsertUser } from "@/lib/users";
  * Onboarding server actions.
  *
  * These are live now. `connectGoogle` starts the scope grant and
- * `completeOnboarding` writes the profile and seals the portal password. The
- * pieces sit in four places for a reason (docs/design/12-onboarding-persistence.md
- * and docs/design/15-firebase-auth.md):
+ * `completeOnboarding` writes the profile. The pieces sit in four places for a
+ * reason (docs/design/12-onboarding-persistence.md and
+ * docs/design/15-firebase-auth.md):
  *
  *   /api/auth/session       Firebase Auth: who the student is
- *   this file               validation, and the two writes onboarding owns
+ *   this file               validation, and the profile write onboarding owns
  *   /onboarding/callback    the return leg from the scope grant
  *   connector on Cloud Run  the code exchange and the refresh token
+ *
+ * The portal password is not here. It used to be the second write this file
+ * made, and it moved to /portal-login with issue #54, where `savePortalLogin`
+ * in app/dashboard/actions.ts seals it on demand. See
+ * docs/design/23-portal-login-handoff.md.
  *
  * No OAuth secret is reachable from this process. See docs/design/07-backend-contract.md.
  */
@@ -130,10 +134,17 @@ export async function connectGoogle(
 }
 
 /**
- * Final submit. Writes the profile and the portal credential.
+ * Final submit. Writes the profile.
  *
- *   users/{uid}                              profile, consent evidence, username
- *   users/{uid}/credentials/school_password  the sealed password
+ *   users/{uid}    profile, consent evidence, the access switches
+ *
+ * It used to write a second document, the sealed portal password, and it no
+ * longer does: `users/{uid}/credentials/school_password` is written from
+ * /portal-login when Classy asks for it. An account can therefore finish
+ * onboarding with no portal login at all, and every reader of that document has
+ * to be fine with the credential being absent rather than treating it as a
+ * half-written account. The dashboard already was; the agent's
+ * `CredentialNotFound` is the signal that it is time to send the link.
  *
  * Identity comes from the session cookie and the user document, never from the
  * form. The form is client-supplied, and the whole point of the SMS round trip
@@ -209,31 +220,14 @@ export async function completeOnboarding(
    */
   const timeZone = resolveTimeZone(formData.get("timeZone"), school?.timeZone);
 
-  // Portal credentials. Google OAuth authorises mail, calendar, and Drive, but
-  // it does not create a session on the school's LMS, and the agent has to sign
-  // in there overnight while the student is asleep. That is what this is for.
-  const portalUser = String(formData.get("portalUser") ?? "").trim();
-  if (portalUser.length < 2) {
-    errors.portalUser = "Enter the username you use on the school portal.";
-  }
-
-  // DELIBERATE, DO NOT REMOVE: the portal password is never logged, never
-  // echoed into a response, and never included in an error message. It goes
-  // straight into savePortalCredentials() below and nowhere else, and it exists
-  // in this process only long enough to be encrypted.
-  //
-  // It does reach Firestore now, which the previous version of this comment
-  // said it never would. What reaches Firestore is AES-256-GCM ciphertext under
-  // a data key wrapped by `classistant-password-key`, which this app can lock
-  // and cannot open -- so `datastore.user` on the document buys an attacker
-  // nothing. See lib/portalCredentials.ts and docs/design/19.
-  //
-  // It is stored reversibly, not hashed. The agent has to replay it into the
-  // school portal overnight, so hashing is not an option here.
-  const portalPassword = String(formData.get("portalPassword") ?? "");
-  if (portalPassword.length < 6) {
-    errors.portalPassword = "Enter your portal password.";
-  }
+  /*
+   * No portal fields are read here, and none should be added back. This form
+   * is public and its hidden inputs are mirrored from wizard state; a password
+   * field on it would travel with every submit whether or not the step that
+   * asked for it was ever shown. The portal login has its own form on its own
+   * page (/portal-login) with its own action, and the rule that governs the
+   * password there is written above `savePortalLogin`.
+   */
 
   /*
    * The number is NOT read from the form any more.
@@ -297,17 +291,11 @@ export async function completeOnboarding(
       access,
     });
 
-    await savePortalCredentials({
-      userId: profile.userId,
-      username: portalUser,
-      password: portalPassword,
-    });
-
     await markOnboardingComplete(profile.userId);
   } catch (err) {
-    // Never let the error text reach the student: a Firestore or KMS failure
-    // can echo back argument values, and one of the arguments here is a portal
-    // password.
+    // Never let the error text reach the student. Nothing in this write is
+    // secret any more, but a Firestore failure can echo back argument values
+    // and the shape of a document is not something to show on a form.
     console.error("completeOnboarding failed", {
       userId: profile.userId,
       error: err instanceof Error ? err.message : "unknown",

--- a/src/frontend/app/portal-login/page.tsx
+++ b/src/frontend/app/portal-login/page.tsx
@@ -1,0 +1,152 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { Suspense } from "react";
+
+import { PhoneSignIn } from "@/components/auth/PhoneSignIn";
+import { OnboardingFrame } from "@/components/onboarding/shell";
+import { PortalLoginHandoff } from "@/components/portal/PortalLoginHandoff";
+import { themeCss } from "@/components/theme/themeVars";
+import { getSchool } from "@/data/schools";
+import { getSession } from "@/lib/authSession";
+import { listSchools } from "@/lib/schools";
+import { getAccount, hasPortalPassword } from "@/lib/users";
+
+export const metadata: Metadata = {
+  title: "Add your portal login",
+  description: "Give Classistant the school portal login it needs to check your courses overnight.",
+  // A page reached from a text message, about one student's account. Nothing
+  // here is for a crawler.
+  robots: { index: false, follow: false },
+};
+
+// Reads the session cookie.
+export const dynamic = "force-dynamic";
+
+/**
+ * /portal-login?phone=+1...
+ *
+ * Where Classy sends a student when it needs their school portal login. This
+ * used to be a step in onboarding; docs/design/23 has the reasons it is a page
+ * of its own now, and the short version is that the ask is easier to say yes
+ * to from someone who has already done something for you.
+ *
+ * ## The `phone` parameter proves nothing, and that is fine
+ *
+ * The link Classy texts carries the number it texted, so the student arriving
+ * from that text can skip typing it and go straight to the six digit code.
+ * That is the whole job of the parameter: a prefill. It is never read on the
+ * server, never compared to anything, and never used to decide whose account
+ * this is. Identity comes from the SMS round trip exactly as it does on
+ * /signin, and a student who is already signed in never sees the number field
+ * at all.
+ *
+ * ## Three states
+ *
+ *   signed out            the number and the code, then back here
+ *   signed in, unfinished sent to onboarding, since there is no account to
+ *                         attach a portal login to yet
+ *   signed in, finished   the form
+ *
+ * The session reads sit below a Suspense boundary for the reason /signin and
+ * /onboarding put theirs there: verifying the cookie is a network call to
+ * Firebase, and a student tapping a link in Messages should see the card
+ * before it finishes.
+ */
+export default async function PortalLoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ phone?: string }>;
+}) {
+  const { phone } = await searchParams;
+
+  return (
+    // The onboarding wash, not the dashboard frame. This is a hand-off page a
+    // student arrives at from a text and leaves from, not a place they
+    // navigate around in, so the nav rail would be furniture for a room they
+    // are passing through. The school theme is emitted below, once the
+    // account is known.
+    <OnboardingFrame>
+      <main id="main" className="mx-auto w-full max-w-[42rem]">
+        <div className="rounded-[1.4rem] bg-white p-6 shadow-soft ring-1 ring-line sm:p-8">
+          <Suspense fallback={<HandoffSkeleton />}>
+            <Gate phoneHint={phone ?? ""} />
+          </Suspense>
+        </div>
+      </main>
+    </OnboardingFrame>
+  );
+}
+
+async function Gate({ phoneHint }: { phoneHint: string }) {
+  const session = await getSession();
+
+  if (!session) {
+    return (
+      <>
+        <h1 className="text-[1.6rem] font-extrabold leading-tight text-ink-900">
+          Sign in to continue
+        </h1>
+        <p className="mt-2.5 text-[0.95rem] leading-[1.6] text-body">
+          Classy sent you here to add your school portal login. Your number is your login, so we
+          text you a code first.
+        </p>
+        <div className="mt-7">
+          {/* `next` is a literal this file wrote. It must stay that way: a
+              destination read from the URL would make this page an open
+              redirect wearing a sign-in form. */}
+          <PhoneSignIn initialPhone={phoneHint} next="/portal-login" />
+        </div>
+      </>
+    );
+  }
+
+  const account = await getAccount(session.uid);
+  if (!account?.onboardingComplete) {
+    redirect(
+      account?.schoolId
+        ? `/onboarding?school=${encodeURIComponent(account.schoolId)}`
+        : "/onboarding",
+    );
+  }
+
+  const [sealed, schools] = await Promise.all([hasPortalPassword(session.uid), listSchools()]);
+  const school = account.schoolId ? (getSchool(schools, account.schoolId) ?? null) : null;
+  const css = school ? themeCss(school) : null;
+
+  return (
+    <>
+      {/* The school's colours, as a server-rendered stylesheet. Later in the
+          document than the frame's own <style> would be, so it wins on equal
+          specificity, and the frame above rendered none because it did not know
+          the school yet. Same mechanism as DashboardFrame. */}
+      {css ? <style dangerouslySetInnerHTML={{ __html: css }} /> : null}
+      <PortalLoginHandoff
+        school={school}
+        username={account.schoolUsername}
+        hasPassword={sealed}
+        phone={session.phone}
+      />
+    </>
+  );
+}
+
+/** Roughly the height of the signed-out card, so whichever state lands does
+ *  not move the page much. Not a shimmer, for the reason /signin gives. */
+function HandoffSkeleton() {
+  return (
+    <>
+      <div aria-hidden="true" className="flex flex-col gap-5">
+        <div className="h-8 w-3/5 rounded-lg bg-line-soft" />
+        <div className="h-4 w-11/12 rounded bg-line-soft/70" />
+        <div className="mt-2 flex flex-col gap-2">
+          <div className="h-4 w-32 rounded bg-line-soft" />
+          <div className="h-[3.1rem] rounded-xl bg-line-soft/60" />
+        </div>
+        <div className="h-[3.3rem] rounded-xl bg-line-soft" />
+      </div>
+      <p className="sr-only" role="status">
+        Loading.
+      </p>
+    </>
+  );
+}

--- a/src/frontend/app/privacy/page.tsx
+++ b/src/frontend/app/privacy/page.tsx
@@ -41,14 +41,14 @@ const SECTIONS: LegalSection[] = [
       <>
         <p>We collect four kinds of information, and no more than the assistant needs to work.</p>
         <p>
-          <Strong>Information you give us during onboarding.</Strong>
+          <Strong>Information you give us, at sign-up or later.</Strong>
         </p>
         <LegalList
           items={[
             "Your full name and your school email address.",
             "Your school, so we know which portal to sign in to.",
             "Your Canadian mobile number, which is where texts and calls go.",
-            "Your student portal username and password.",
+            "Your student portal username and password, when the assistant asks for them.",
             "Your preferences: how hard the assistant should push, your quiet hours, and whether you want phone calls.",
           ]}
         />

--- a/src/frontend/app/signin/page.tsx
+++ b/src/frontend/app/signin/page.tsx
@@ -101,7 +101,7 @@ export default function SignInPage() {
  *
  * Two destinations, because being signed in is not the same as being finished:
  * a student who verified a number and then closed the tab holds a valid session
- * and an account with no school, no grant, and no portal password. The
+ * and an account with no school, no grant, and no consents. The
  * dashboard would render for them and be almost entirely empty, so they go back
  * to the flow that fills it.
  */

--- a/src/frontend/components/auth/PhoneSignIn.tsx
+++ b/src/frontend/components/auth/PhoneSignIn.tsx
@@ -30,7 +30,14 @@ import {
  * establishing an identity for the first time and everything after it is a
  * step; this is a returning student who already has an account and wants to be
  * somewhere else within two taps. It ends in a redirect, and the wizard's
- * version cannot, because for it the number is step one of four.
+ * version cannot, because for it the number is step one of three.
+ *
+ * Two callers now: /signin, and /portal-login, which Classy texts to a student
+ * when it needs their school login. The second one arrives with the number
+ * already known (it is the number the text went to) and wants the student back
+ * on its own page afterwards, so both of those are props. Neither is trusted
+ * for anything: the prefill is convenience and the code still has to arrive,
+ * and the destination is a path the caller wrote, not one from the URL.
  */
 
 /** Where the invisible reCAPTCHA mounts. A different id from the wizard's, so
@@ -55,8 +62,22 @@ type SessionResponse = {
   error?: string;
 };
 
-export function PhoneSignIn() {
-  const [phone, setPhone] = useState("");
+export function PhoneSignIn({
+  initialPhone = "",
+  next,
+}: {
+  /** A number to start the field with, run through `formatPhone` on the way in
+   *  so anything from a raw E.164 to garbage becomes at most ten digits. A
+   *  prefill only: it proves nothing, and the code still has to be delivered to
+   *  it and typed back. */
+  initialPhone?: string;
+  /** Where a finished account lands once signed in. Defaults to the dashboard.
+   *  An account that never finished onboarding goes back to onboarding whatever
+   *  this says, because there is nothing for it to do anywhere else yet. Must
+   *  be a path this code wrote, never one read from the request. */
+  next?: string;
+} = {}) {
+  const [phone, setPhone] = useState(() => formatPhone(initialPhone));
   const [code, setCode] = useState("");
   const [pending, setPending] = useState<PendingVerification | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -116,7 +137,7 @@ export function PhoneSignIn() {
        */
       window.location.assign(
         data.onboardingComplete
-          ? "/dashboard"
+          ? (next ?? "/dashboard")
           : `/onboarding${data.schoolId ? `?school=${encodeURIComponent(data.schoolId)}` : ""}`,
       );
     } catch (err) {

--- a/src/frontend/components/dashboard/PortalLoginForm.tsx
+++ b/src/frontend/components/dashboard/PortalLoginForm.tsx
@@ -4,7 +4,7 @@ import { useActionState, useState } from "react";
 
 import { savePortalLogin } from "@/app/dashboard/actions";
 import { SaveState, buttonClass } from "@/components/dashboard/ui";
-import { Field, TextInput } from "@/components/onboarding/fields";
+import { PortalLoginFields } from "@/components/portal/PortalLoginFields";
 
 /**
  * Replacing the school portal login.
@@ -100,43 +100,16 @@ export function PortalLoginForm({
         leave you in.
       </p>
 
-      <Field
-        label="Portal username or student number"
-        htmlFor="portal-user"
-        error={errors.portalUser}
-        hint="Some schools use a username here, others your student number."
-      >
-        <TextInput
-          id="portal-user"
-          name="portalUser"
-          defaultValue={username ?? ""}
-          autoComplete="off"
-          invalid={Boolean(errors.portalUser)}
-        />
-      </Field>
-
-      <Field label="New portal password" htmlFor="portal-password" error={errors.portalPassword}>
-        <div className="relative">
-          <TextInput
-            id="portal-password"
-            name="portalPassword"
-            type={show ? "text" : "password"}
-            // new-password, so a browser does not offer a saved credential from
-            // an unrelated site into a field that gets sealed and never read
-            // back.
-            autoComplete="new-password"
-            className="pr-20"
-            invalid={Boolean(errors.portalPassword)}
-          />
-          <button
-            type="button"
-            onClick={() => setShow((v) => !v)}
-            className="absolute right-3 top-1/2 -translate-y-1/2 rounded-md px-2 py-1 text-[0.78rem] font-semibold text-brand-600 hover:bg-sky-100"
-          >
-            {show ? "Hide" : "Show"}
-          </button>
-        </div>
-      </Field>
+      {/* The same two fields /portal-login shows. "New" on the label because
+          this form only ever opens over an existing login, or over the absence
+          of one, and either way the student is not confirming a value. */}
+      <PortalLoginFields
+        defaultUsername={username ?? ""}
+        errors={errors}
+        show={show}
+        onToggleShow={() => setShow((v) => !v)}
+        passwordLabel={hasPassword ? "New portal password" : "Portal password"}
+      />
 
       <SaveState state={state} />
 

--- a/src/frontend/components/onboarding/OnboardingWizard.tsx
+++ b/src/frontend/components/onboarding/OnboardingWizard.tsx
@@ -10,11 +10,7 @@ import {
   type Identity,
 } from "@/app/onboarding/actions";
 import { SchoolPicker } from "@/components/onboarding/SchoolPicker";
-import {
-  ConnectScene,
-  SceneCard,
-  SealedPasswordScene,
-} from "@/components/onboarding/connectScenes";
+import { ConnectScene, SceneCard } from "@/components/onboarding/connectScenes";
 import { Choice, Field, TextInput, formatPhone } from "@/components/onboarding/fields";
 import { PhoneVerifyScene } from "@/components/onboarding/phoneScenes";
 import { Shell } from "@/components/onboarding/shell";
@@ -39,13 +35,12 @@ import {
 } from "@/lib/firebaseClient";
 
 /**
- * Four screens. The school is already chosen in the hero and arrives as
+ * Three screens. The school is already chosen in the hero and arrives as
  * ?school=, so this starts at the number.
  *
- * Order: verify your number, connect Google, portal password, choose what it
- * may touch.
+ * Order: verify your number, connect Google, choose what it may touch.
  *
- * Three deliberate placements:
+ * Two deliberate placements, and one deliberate absence:
  *
  * The **phone number is first**, which is the reverse of where it used to be.
  * It used to sit last, behind the Finish button, on the reasoning that a field
@@ -56,31 +51,32 @@ import {
  * after it is attached to a verified person rather than to a session that could
  * be anyone.
  *
- * The **portal password comes after Google**, not before. Google has just
- * demonstrated a normal consent flow at that point, which is the best possible
- * moment to ask for something less normal. It is still needed despite the OAuth
- * grant: OAuth authorises mail, calendar, and Drive, but it does not create a
- * session on the school's LMS, and the agent has to sign in there overnight
- * while the student is asleep and cannot approve anything.
- *
  * The **access switches come last**, after the grant rather than before it.
  * Google's consent screen is all or nothing, so a student cannot narrow it
  * there; the only place a real choice can be offered is afterwards, and the
  * Google step says so in as many words before sending them.
+ *
+ * **There is no portal password step.** There was one, between Google and the
+ * switches, and it was the biggest ask in the flow: a second login, typed into
+ * a site the student met four minutes ago, before anything had been done for
+ * them. Issue #54 took it out. The password is still needed, for the reason it
+ * always was (OAuth authorises mail, calendar and Drive and creates no session
+ * on the school's LMS), but it is asked for at /portal-login when Classy first
+ * needs it, from a student who is already getting texts and has a reason to say
+ * yes. See docs/design/23-portal-login-handoff.md.
  */
 
-/** The heading on each screen. Four screens, but three PHASES: see shell.tsx. */
+/** The heading on each screen. Three screens, and three PHASES: see shell.tsx. */
 const STEP_TITLES = [
   "What is your number?",
   "Connect your school account",
-  "Let it work while you sleep",
   "Choose what it can touch",
 ];
 
-/** Screens 0 to 2 are all logging in; the last one is the reward. The three
+/** Screens 0 and 1 are both logging in; the last one is the reward. The three
  *  phases they map onto, and the card that draws them, live in
  *  components/onboarding/shell.tsx so the loading boundary can render them too. */
-const phaseForStep = (step: number) => (step <= 2 ? 1 : 2);
+const phaseForStep = (step: number) => (step <= 1 ? 1 : 2);
 
 /**
  * Shape check for the number, so the button can gate on it.
@@ -150,7 +146,7 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
    *
    *   nothing            step 0, the number
    *   number verified    step 1, connect Google
-   *   grant complete     step 2, the portal password
+   *   grant complete     step 2, the switches and the finish
    *
    * Coming back from the consent screen is the third case, which is why a
    * student never re-does a step they finished before leaving the page.
@@ -221,10 +217,6 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
 
   /** The part before the @, which is all the field lets them edit. */
   const localPart = schoolEmail.replace(/@.*$/, "");
-
-  const [portalUser, setPortalUser] = useState("");
-  const [portalPassword, setPortalPassword] = useState("");
-  const [showPassword, setShowPassword] = useState(false);
 
   const [acceptTerms, setAcceptTerms] = useState(false);
   const [acceptMarketing, setAcceptMarketing] = useState(false);
@@ -643,8 +635,9 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
           <div className="mt-7 flex flex-col gap-5">
             {/* Reason left, demonstration right, at the same half width as
                 every other scene in the wizard. These two used to share a row
-                with SealedPasswordScene, which is where that size comes from;
-                giving each its own step is not a reason to double it. */}
+                with the sealed-envelope scene (now on /portal-login), which is
+                where that size comes from; having the row to itself is not a
+                reason to double it. */}
             <div className="grid items-center gap-5 sm:grid-cols-2">
               <div className="flex flex-col gap-3">
                 <p className="text-[1.05rem] font-semibold leading-[1.45] text-ink-900">
@@ -751,109 +744,8 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
           </div>
         ) : null}
 
-        {/* ------------------------------------------ 3. portal password */}
+        {/* ------------------------------------ 3. what it can touch */}
         {step === 2 ? (
-          <div className="mt-7 flex flex-col gap-5">
-            {/* Same pairing as the other two steps. The explanation lost its
-                sky-50 callout box in the move: beside a SceneCard, which carries
-                its own ring, two ringed boxes side by side read as competing
-                panels, and the four-point list further down this step is already
-                doing the work a callout would. */}
-            <div className="grid items-center gap-5 sm:grid-cols-2">
-              <div className="flex flex-col gap-3">
-                <p className="text-[1.05rem] font-semibold leading-[1.45] text-ink-900">
-                  Google does not get it into your portal.
-                </p>
-                <p className="text-[0.9rem] leading-[1.6] text-body">
-                  That is where posted grades and course files live. Classistant checks it
-                  overnight, while you are asleep and cannot approve anything, so it needs to
-                  be able to sign in on its own.
-                </p>
-              </div>
-
-              {/* Moved here from the connect step, which resolves the concern
-                  docs/design/13 raises about itself: the sealed envelope is a
-                  simplification of the Google grant and very nearly literal
-                  about the portal password. This is the step it is accurate on,
-                  and the step it argues for. */}
-              <SceneCard>
-                <SealedPasswordScene school={school} />
-              </SceneCard>
-            </div>
-
-            {/*
-              The placeholder is generic on purpose.
-
-              It used to be `localPart` -- the student's own name, taken from
-              the address they just connected. Rendered in placeholder grey it
-              reads exactly like a filled-in field, so a student who had typed
-              only the password saw two complete fields and a Continue button
-              that would not respond, with nothing on screen naming the empty
-              one. The suggestion is worth making, so it moved to the hint,
-              where it is offered rather than impersonated.
-            */}
-            <Field
-              label="Portal username or student number"
-              htmlFor="portalUser"
-              error={errors.portalUser}
-              hint={
-                localPart
-                  ? `Often the same as your school email name, ${localPart} — but some schools want your student number instead.`
-                  : "Some schools use a username here, others your student number."
-              }
-            >
-              <TextInput
-                id="portalUser"
-                name="portalUser"
-                value={portalUser}
-                onChange={(e) => setPortalUser(e.target.value)}
-                autoComplete="off"
-                invalid={Boolean(errors.portalUser)}
-              />
-            </Field>
-
-            <Field label="Portal password" htmlFor="portalPassword" error={errors.portalPassword}>
-              <div className="relative">
-                <TextInput
-                  id="portalPassword"
-                  name="portalPassword"
-                  type={showPassword ? "text" : "password"}
-                  value={portalPassword}
-                  onChange={(e) => setPortalPassword(e.target.value)}
-                  // new-password, so browsers do not offer a saved credential
-                  // from an unrelated site.
-                  autoComplete="new-password"
-                  className="pr-20"
-                  invalid={Boolean(errors.portalPassword)}
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword((v) => !v)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 rounded-md px-2 py-1 text-[0.78rem] font-semibold text-brand-600 hover:bg-sky-100"
-                >
-                  {showPassword ? "Hide" : "Show"}
-                </button>
-              </div>
-            </Field>
-
-            <ul className="flex flex-col gap-2 rounded-xl bg-paper p-4 ring-1 ring-line">
-              {[
-                "Encrypted at rest, with keys held separately.",
-                "Only ever sent to your school's own login page.",
-                "Never shown back to you, and no staff member can read it.",
-                "Destroyed the moment you delete your account.",
-              ].map((line) => (
-                <li key={line} className="flex items-start gap-2.5 text-[0.84rem] text-ink-800">
-                  <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-sky-400" />
-                  {line}
-                </li>
-              ))}
-            </ul>
-          </div>
-        ) : null}
-
-        {/* ------------------------------------ 4. what it can touch */}
-        {step === 3 ? (
           <div className="mt-7 flex flex-col gap-5">
             <p className="text-[0.95rem] leading-[1.6] text-body">
               Google asked for everything at once, because that is the only way it asks. Here
@@ -1012,8 +904,6 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
             // ever here. The student has nothing to say about it: it is what
             // their browser reports.
             timeZone,
-            portalUser,
-            portalPassword,
             acceptTerms: acceptTerms ? "on" : "",
             acceptMarketing: acceptMarketing ? "on" : "",
             consentSms: consentSms ? "on" : "",
@@ -1052,35 +942,23 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
           </p>
         ) : null}
 
-        <div className="mt-9 flex items-center justify-between gap-4 border-t border-line-soft pt-6">
-          <button
-            type="button"
-            onClick={() => setStep((s) => Math.max(0, s - 1))}
-            // Nothing to go back to on step 0, and nothing worth going back to
-            // on step 1: the number is already verified and the account already
-            // connected, so Back would only offer to redo settled work.
-            disabled={step <= 1}
-            className="rounded-lg px-3 py-2 text-[0.9rem] font-semibold text-body transition-colors hover:bg-sky-100 hover:text-ink-900 disabled:pointer-events-none disabled:opacity-0"
-          >
-            Back
-          </button>
+        {/*
+          No Back button. There was one, and with the portal step gone it has
+          nowhere worth going: step 0 is the start, and steps 1 and 2 each sit
+          behind a proof (a delivered code, a completed grant) that pressing
+          Back could only offer to redo. A student on the wrong number has "Not
+          your number?" on the first screen, and a different Google account is a
+          reconnect from the dashboard.
 
-          {step === 2 ? (
-            <button
-              type="button"
-              onClick={() => setStep(3)}
-              disabled={portalUser.trim().length < 2 || portalPassword.length < 6}
-              className="rounded-xl bg-brand-600 px-6 py-3 text-[0.93rem] font-semibold text-white transition-colors hover:bg-brand-700 disabled:cursor-not-allowed disabled:bg-line disabled:text-body-soft"
-            >
-              Continue
-            </button>
-          ) : null}
-
-          {step === 3 ? (
-            // Named for what it produces rather than for what it does. The
-            // screen above it is the one where a student finds out the beta is
-            // free, and "Send welcome gift" is the reward rather than the
-            // paperwork. Same reasoning as the PHASES label.
+          The row is only drawn on the last screen, because it is the only one
+          with a button in it: steps 0 and 1 carry their own actions inline.
+        */}
+        {step === 2 ? (
+          <div className="mt-9 flex items-center justify-end gap-4 border-t border-line-soft pt-6">
+            {/* Named for what it produces rather than for what it does. The
+                screen above it is the one where a student finds out the beta is
+                free, and "Send welcome gift" is the reward rather than the
+                paperwork. Same reasoning as the PHASES label. */}
             <div className="flex flex-col items-end gap-2">
               <button
                 type="submit"
@@ -1100,8 +978,8 @@ export function OnboardingWizard({ connected }: { connected: ConnectedAccount | 
                 </p>
               ) : null}
             </div>
-          ) : null}
-        </div>
+          </div>
+        ) : null}
       </form>
 
       {/*
@@ -1206,9 +1084,10 @@ function HiddenState({ step, values }: { step: number; values: Record<string, st
   const rendered: Record<number, string[]> = {
     // Steps 0 and 1 render nothing that travels with the final submit. The
     // number and the code are deliberately absent from the form entirely:
-    // neither is submitted, they reach the server by being verified.
-    2: ["portalUser", "portalPassword"],
-    3: ["name", "acceptTerms", "consentSms", "acceptMarketing"],
+    // neither is submitted, they reach the server by being verified. The
+    // portal fields that used to be listed here are gone with their step; they
+    // live at /portal-login now and never pass through this form.
+    2: ["name", "acceptTerms", "consentSms", "acceptMarketing"],
   };
   const skip = new Set(rendered[step] ?? []);
   return (
@@ -1236,10 +1115,14 @@ function DoneScreen({ name, phone, school }: { name: string; phone: string; scho
       <h1 className="mt-7 text-[2rem] font-extrabold leading-tight text-ink-900">
         You are set up{name ? `, ${name.split(" ")[0]}` : ""}
       </h1>
+      {/* The portal is mentioned here and nowhere earlier in the wizard. This
+          is the first moment a student has finished something and can hear
+          "one more thing, later" without it costing the signup. */}
       <p className="mt-4 text-[1rem] leading-[1.7] text-body">
-        Classistant is reading {school?.name ?? "your school"} now. Within about ten minutes you
-        will get a text at <span className="font-semibold text-ink-900">{phone}</span> with every
-        deadline it found.
+        Classistant is reading your {school?.name ?? "school"} mail and calendar now. Within
+        about ten minutes you will get a text at{" "}
+        <span className="font-semibold text-ink-900">{phone}</span> with every deadline it
+        found. When it needs your school portal, Classy will text you a link for that.
       </p>
 
       <TextClassyCard />

--- a/src/frontend/components/onboarding/connectScenes.tsx
+++ b/src/frontend/components/onboarding/connectScenes.tsx
@@ -5,14 +5,18 @@ import { schoolInitials } from "@/data/schools";
 import { useSceneClock } from "@/components/landing/sceneParts";
 
 /**
- * Two looping scenes for step one of onboarding.
+ * Two looping scenes, drawn for two asks that sound alarming written down.
  *
- * Step one asks a student to do something that sounds alarming written down:
- * hand a website their school login. The copy answered that in one sentence,
- * and a sentence is the weakest form the answer can take. These show it.
+ * Each asks a student to hand a website a school login. The copy answered that
+ * in one sentence, and a sentence is the weakest form the answer can take.
+ * These show it.
  *
- *   ConnectScene         what to type, then what Google will ask them to allow
- *   SealedPasswordScene  why "Classistant never sees your password" is true
+ *   ConnectScene         what to type, then what Google will ask them to allow.
+ *                        On the Google step of onboarding.
+ *   SealedPasswordScene  why "Classistant never sees your password" is true.
+ *                        On /portal-login, where the portal password is asked
+ *                        for since #54 took it out of onboarding. It was drawn
+ *                        for that ask and went with it.
  *
  * They follow the machinery in components/landing/sceneParts: one clock per
  * scene, views derived from the current time. Beats keep getting re-cut during

--- a/src/frontend/components/onboarding/shell.tsx
+++ b/src/frontend/components/onboarding/shell.tsx
@@ -35,7 +35,9 @@ import type { School } from "@/data/schools";
  * the school picker before them, so the flow announced itself as five things to
  * get through before anything happened. It is three: pick a school, sign in,
  * confirm your details. The two sign-in screens are one job with a technical
- * seam in the middle, and the same is true of the last two.
+ * seam in the middle. (There are three screens now rather than four, since the
+ * portal password left for /portal-login, and the phases did not move: they
+ * were already counting jobs rather than screens.)
  *
  * Counting this way also means the school picker is worth something. It was
  * unnumbered, so a student arriving at screen two had done a third of the work
@@ -128,11 +130,11 @@ export function Shell({
    * Whether to offer the way back in to somebody who already has an account.
    *
    * A prop rather than something derived from `phase`, because the phases do
-   * not draw the line in the right place: phase 1 covers the number, the Google
-   * grant, and the portal password, and this belongs under the first of those
-   * three and nowhere near the other two. Offering "Sign in" to a student who
-   * has already verified their number two screens ago is offering to send them
-   * back to the beginning of what they are in the middle of.
+   * not draw the line in the right place: phase 1 covers the number and the
+   * Google grant, and this belongs under the first of those two and nowhere
+   * near the second. Offering "Sign in" to a student who has already verified
+   * their number a screen ago is offering to send them back to the beginning of
+   * what they are in the middle of.
    */
   showSignIn?: boolean;
   children: React.ReactNode;
@@ -185,7 +187,7 @@ export function Shell({
       The door for somebody who is already set up.
 
       Under the card rather than inside it, and quiet rather than a button. This
-      page has exactly one job, which is to get a new student through four
+      page has exactly one job, which is to get a new student through three
       screens, and a prominent second call to action at the top of it is an
       invitation to leave the flow. But a returning student who lands here -- and
       they do, because /onboarding was the only door this site had until the

--- a/src/frontend/components/portal/PortalLoginFields.tsx
+++ b/src/frontend/components/portal/PortalLoginFields.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Field, TextInput } from "@/components/onboarding/fields";
+
+/**
+ * The two portal fields, shared by the dashboard's replace form and the
+ * /portal-login hand-off.
+ *
+ * Extracted rather than written twice because they are genuinely one thing:
+ * the same two names (`portalUser`, `portalPassword`) read by the same server
+ * action, the same error keys, and the same show/hide toggle. What differs
+ * between the two callers is everything around them (one collapses to a button
+ * by default, the other opens ready to type, and they end differently), and
+ * none of that is in here. Compare PhoneSignIn, which argues the opposite way
+ * about its two fields: there the fields were the only thing in common and the
+ * flows around them were the point.
+ *
+ * Uncontrolled inputs. The password never needs to be in React state: it goes
+ * from the field to the form submit to `savePortalCredentials` and is sealed,
+ * and holding it in state would only make a second copy to worry about.
+ */
+export function PortalLoginFields({
+  defaultUsername,
+  errors,
+  show,
+  onToggleShow,
+  passwordLabel = "Portal password",
+}: {
+  defaultUsername: string;
+  errors: Record<string, string>;
+  show: boolean;
+  onToggleShow: () => void;
+  /** "New portal password" on the replace form, where there is an old one. */
+  passwordLabel?: string;
+}) {
+  return (
+    <>
+      <Field
+        label="Portal username or student number"
+        htmlFor="portal-user"
+        error={errors.portalUser}
+        hint="Some schools use a username here, others your student number."
+      >
+        <TextInput
+          id="portal-user"
+          name="portalUser"
+          defaultValue={defaultUsername}
+          autoComplete="off"
+          invalid={Boolean(errors.portalUser)}
+        />
+      </Field>
+
+      <Field label={passwordLabel} htmlFor="portal-password" error={errors.portalPassword}>
+        <div className="relative">
+          <TextInput
+            id="portal-password"
+            name="portalPassword"
+            type={show ? "text" : "password"}
+            // new-password, so a browser does not offer a saved credential from
+            // an unrelated site into a field that gets sealed and never read
+            // back.
+            autoComplete="new-password"
+            className="pr-20"
+            invalid={Boolean(errors.portalPassword)}
+          />
+          <button
+            type="button"
+            onClick={onToggleShow}
+            className="absolute right-3 top-1/2 -translate-y-1/2 rounded-md px-2 py-1 text-[0.78rem] font-semibold text-brand-600 hover:bg-sky-100"
+          >
+            {show ? "Hide" : "Show"}
+          </button>
+        </div>
+      </Field>
+    </>
+  );
+}

--- a/src/frontend/components/portal/PortalLoginHandoff.tsx
+++ b/src/frontend/components/portal/PortalLoginHandoff.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import Link from "next/link";
+import { useActionState, useState } from "react";
+
+import { savePortalLogin } from "@/app/dashboard/actions";
+import { LogoMark } from "@/components/brand/LogoMark";
+import { SaveState, buttonClass } from "@/components/dashboard/ui";
+import { SceneCard, SealedPasswordScene } from "@/components/onboarding/connectScenes";
+import { PortalLoginFields } from "@/components/portal/PortalLoginFields";
+import { CLASSY_SMS_HREF } from "@/data/classy";
+import type { School } from "@/data/schools";
+
+/**
+ * The page Classy texts when it needs the school portal login.
+ *
+ * ## Why this is a page of its own
+ *
+ * This form used to be step three of onboarding, between the Google grant and
+ * the access switches. It was the biggest ask in the flow and it landed at the
+ * worst moment: a second password, for a site the student met four minutes
+ * ago, before anything had been done for them. Issue #54 moved it out. Now the
+ * student finishes signup, gets their first texts, and only meets this screen
+ * when Classy actually has a reason to go into the portal and says so.
+ *
+ * The heading is the one the onboarding step carried, because it was already
+ * the right one: it names the benefit rather than the credential.
+ *
+ * ## What it stores, and where
+ *
+ * The same thing the onboarding step stored, in the same place, through the
+ * same action the dashboard's replace form uses: `savePortalLogin` seals the
+ * password under `classistant-password-key` into
+ * `users/{uid}/credentials/school_password` and records the username on the
+ * user document. This app can lock that credential and cannot open it; the
+ * browser agent is the only principal that can (docs/ENCRYPTION_CONTRACT.md
+ * §1). Nothing about the storage changed when the form moved, and the
+ * reasoning for not making it ephemeral is in docs/design/23.
+ *
+ * ## Open by default
+ *
+ * The dashboard's form collapses to a button, because there a password field
+ * sitting open invites a browser to fill it from an unrelated site and a
+ * student to retype something they did not need to change. Here the student
+ * tapped a link whose entire purpose is this form. Making them press "Add your
+ * portal login" first would be asking them to confirm the thing they just did.
+ *
+ * ## It ends, rather than staying open
+ *
+ * The done state replaces the form. The student came from Messages and should
+ * go back there, so the filled button is the way back to Classy and the
+ * dashboard is the secondary door. Reloading the page shows the form again
+ * with "already sealed" noted above it, which is the honest state: there is a
+ * password stored, and typing here replaces it.
+ */
+export function PortalLoginHandoff({
+  school,
+  username,
+  hasPassword,
+  phone,
+}: {
+  school: School | null;
+  /** The stored portal username, prefilled so a replace is one field. */
+  username: string | null;
+  /** Whether a sealed credential exists. Not whether it still works: nothing
+   *  on this side of the KMS boundary can know that. */
+  hasPassword: boolean;
+  /** The signed-in number, shown so a student can tell whose account this is
+   *  before typing a password into it. */
+  phone: string;
+}) {
+  const [state, action, saving] = useActionState(savePortalLogin, null);
+  const [show, setShow] = useState(false);
+  const errors = state?.errors ?? {};
+
+  if (state?.ok) {
+    return <Sealed school={school} />;
+  }
+
+  const portalName = school ? `${school.short ?? school.name} portal` : "school portal";
+
+  return (
+    <form action={action} className="flex flex-col gap-5">
+      <div className="flex items-center justify-between gap-4">
+        <Link href="/" aria-label="Classistant home" className="inline-flex items-center gap-2.5">
+          <LogoMark size={28} />
+          <span className="font-display text-[1.05rem] font-extrabold tracking-[-0.03em] text-ink-900">
+            Classistant
+          </span>
+        </Link>
+        <span
+          aria-label={`Signed in as ${phone}`}
+          className="font-mono text-[0.8rem] text-body-soft"
+        >
+          {phone}
+        </span>
+      </div>
+
+      <h1 className="text-[1.6rem] font-extrabold leading-tight text-ink-900">
+        Let it work while you sleep
+      </h1>
+
+      {/* Reason on the left, demonstration on the right, at the size every
+          scene in onboarding renders at. The sealed envelope is literal about
+          this form: typed here, sealed, replayed against the school's own
+          login page overnight. It was drawn for this ask and it moved here with
+          it. */}
+      <div className="grid items-center gap-5 sm:grid-cols-2">
+        <div className="flex flex-col gap-3">
+          <p className="text-[1.05rem] font-semibold leading-[1.45] text-ink-900">
+            Google does not get it into your {portalName}.
+          </p>
+          <p className="text-[0.9rem] leading-[1.6] text-body">
+            That is where posted grades and course files live. Classistant checks it overnight,
+            while you are asleep and cannot approve anything, so it needs to be able to sign in
+            on its own.
+          </p>
+        </div>
+
+        {school ? (
+          <SceneCard>
+            <SealedPasswordScene school={school} />
+          </SceneCard>
+        ) : null}
+      </div>
+
+      <PortalLoginFields
+        defaultUsername={username ?? ""}
+        errors={errors}
+        show={show}
+        onToggleShow={() => setShow((v) => !v)}
+      />
+
+      <ul className="flex flex-col gap-2 rounded-xl bg-paper p-4 ring-1 ring-line">
+        {[
+          "Encrypted at rest, with keys held separately.",
+          "Only ever sent to your school's own login page.",
+          "Never shown back to you, and no staff member can read it.",
+          "Destroyed the moment you delete your account.",
+        ].map((line) => (
+          <li key={line} className="flex items-start gap-2.5 text-[0.84rem] text-ink-800">
+            <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-sky-400" />
+            {line}
+          </li>
+        ))}
+      </ul>
+
+      {hasPassword ? (
+        <p className="text-[0.82rem] leading-[1.6] text-body-soft">
+          There is already a sealed password on your account. Saving here replaces it, which is
+          the thing to do if you changed it at school and Classy stopped getting in.
+        </p>
+      ) : null}
+
+      <SaveState state={state} />
+
+      <div className="flex flex-wrap items-center gap-3 border-t border-line-soft pt-5">
+        <button type="submit" disabled={saving} className={buttonClass("primary")}>
+          {saving ? "Sealing..." : "Save portal login"}
+        </button>
+        <Link href="/dashboard/access" className={buttonClass("quiet", "sm")}>
+          Not now
+        </Link>
+      </div>
+    </form>
+  );
+}
+
+/**
+ * The done state. Same shape as the wizard's DoneScreen so it reads as the
+ * same product finishing the same kind of thing, with one filled button: back
+ * to the conversation this came from.
+ */
+function Sealed({ school }: { school: School | null }) {
+  return (
+    <div className="text-center">
+      <span className="relative mx-auto grid h-20 w-20 place-items-center rounded-full bg-sky-100">
+        <span
+          aria-hidden="true"
+          className="absolute inset-0 rounded-full bg-sky-300/50 motion-safe:animate-[pulse-ring_2.6s_ease-out_infinite]"
+        />
+        <LogoMark size={42} animated />
+      </span>
+
+      <h1 className="mt-7 text-[1.75rem] font-extrabold leading-tight text-ink-900">Sealed</h1>
+      <p className="mx-auto mt-3 max-w-md text-[0.98rem] leading-[1.7] text-body">
+        Classistant will use it the next time it checks {school?.name ?? "your school"}. You can
+        close this and go back to your texts.
+      </p>
+
+      <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+        <a href={CLASSY_SMS_HREF} className={buttonClass("primary")}>
+          Back to Classy
+        </a>
+        <Link href="/dashboard/access" className={buttonClass("secondary")}>
+          Open my dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/data/access.ts
+++ b/src/frontend/data/access.ts
@@ -76,9 +76,10 @@ export const ACCESS_ITEMS: AccessItem[] = [
   {
     key: "calendar",
     label: "Put due dates in your calendar",
-    detail: "Deadlines it finds become events, so they show up where you already look.",
+    detail:
+      "Deadlines it finds become events, so they show up where you already look. That covers every calendar on your account, not only the main one.",
     field: "calendar",
-    scopes: ["calendar.events", "calendar.events.owned"],
+    scopes: ["calendar.events", "calendar.events.owned", "calendar.calendarlist.readonly"],
   },
   {
     key: "driveRead",

--- a/src/frontend/lib/googleOAuth.ts
+++ b/src/frontend/lib/googleOAuth.ts
@@ -18,16 +18,27 @@ import "server-only";
  */
 
 /**
- * MUST stay identical to `scopes` in the connector's app/config.py.
+ * The one list of Google scopes this product asks for.
  *
- * The connector rebuilds a Credentials object with its own hardcoded scope list
- * and Google validates the granted set during the code exchange. Request a
- * different set here and the exchange either drops permissions the agent needs
- * or throws outright. When config.py changes, change this in the same commit.
+ * This file owns it. It used to have to stay byte-identical to a `scopes` list
+ * in the connector's app/config.py, because the connector rebuilt a Credentials
+ * object from its own copy and google-auth compared the two sets on every
+ * refresh. That list is gone: the connector now builds Credentials from a bare
+ * access token (app/services/firestore_creds.py) and names no scopes at all, so
+ * nothing on that side can disagree with this. Two places still mirror it by
+ * hand and are worth a look when this changes:
+ *
+ *  - scripts/seed_credential.py in the connector, a dev tool that mints a
+ *    refresh token the way onboarding does.
+ *  - the `scopes` cross-reference on each row of data/access.ts, which tells
+ *    the next editor which student-facing switch they have just made a liar.
  *
  * Narrowing this list is safe for students who already consented: google-auth
  * only raises on a scope it asked for and did not get, so an older, broader
- * grant still refreshes. Widening it is the direction that needs re-consent.
+ * grant still refreshes. Widening it is the direction that needs re-consent: a
+ * token granted under the old list simply lacks the new scope, and the first
+ * API call that needs it returns 403 until the student reconnects from
+ * /dashboard/access.
  */
 export const GOOGLE_SCOPES = [
   "openid",
@@ -53,6 +64,22 @@ export const GOOGLE_SCOPES = [
   // events().list and events().insert and owns no delete path at all.
   "https://www.googleapis.com/auth/calendar.events",
   "https://www.googleapis.com/auth/calendar.events.owned",
+  // Read only, and the one calendar scope here that is not about events.
+  //
+  // The two above can read and write events on any calendar the student can
+  // reach, but neither can *name* those calendars: `calendarList.list` sits
+  // outside both, so the connector could only ever address `primary`, and a
+  // student whose course calendar is a second one, or one a TA shares with the
+  // class, was invisible to Classy (issue #49). This lists them and does
+  // nothing else. `calendar` and `calendar.readonly` would also list them and
+  // were not taken: the first is the delete-everything scope docs/design/17
+  // removed, and the second adds reading every event, setting and ACL, none of
+  // which is needed to learn that a calendar exists. See docs/design/24.
+  //
+  // Added 2026-09-03. Anyone who consented before then holds a token without
+  // it, and the connector answers `/calendar/calendars` with 403 until they
+  // reconnect.
+  "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
   // Read only, and both of them: drive.py calls files().list, files().get,
   // export_media and get_media, and nothing that writes.
   //


### PR DESCRIPTION
Closes #49. Closes #54.

Two commits, one per issue. Both are frontend-owned; #49 also carries a small, additive change to the connector's calendar router, flagged below.

## #54: the portal password leaves onboarding

**Before:** number, Google, portal password, switches.
**After:** number, Google, switches. An account can finish with no portal credential.

`/portal-login` is the page Classy texts when it first needs the login. Signed out, it is the phone sign-in with the number prefilled from `?phone=` (a convenience only; identity is still the SMS code). Signed in and finished, it is the old onboarding step with its ending changed: same heading, same two fields, same reassurance list, the sealed-envelope scene that was drawn for this ask, open by default, ending in a "Sealed" card whose one filled button is `sms:` back to Classy. Unfinished accounts are sent to onboarding.

**Storage did not change, and this is the decision to review.** `savePortalLogin` still seals under `classistant-password-key` into `users/{uid}/credentials/school_password`, which is what the browser agent already decrypts. The issue thread proposes an ephemeral Cloudflare KV store instead. I did not adopt it and wrote up why in `docs/design/23-portal-login-handoff.md`: the agent runs while the student is asleep, so a credential that expires in minutes cannot serve the overnight run, and a second vendor for one credential is the two-stores situation doc 19 just removed. If a time limit is wanted, Firestore TTL on the same document gets it without a new vendor. @obaodelana this is an open question for you; the page collects two fields and calls one action, so the answer changes one function and not the page.

**Nothing here sends the link.** That is agent work (#55). Contract for it, also in doc 23: URL is `${NEXT_PUBLIC_APP_URL}/portal-login?phone=<E.164>`, trigger is `CredentialNotFound` from `get_portal_credentials`, and the ten-minute credential cache may need `clear_cache()` after a save. Until wired, the dashboard's Access page and overview tile offer the same form.

Smaller pieces: `PhoneSignIn` gains `initialPhone` and `next`; the two portal fields are shared via `components/portal/PortalLoginFields.tsx`; the Back button is gone from the wizard (every remaining screen is the start or sits behind a proof); the dashboard tile says "Add it" not "Replace it" when nothing is stored; the privacy policy says the credential is given "when the assistant asks for them". Docs 04, 07 and 15 carry pointers.

## #49: Classy only saw the primary calendar

The scope was half the story. `calendar.events` can read and write events on any calendar the student can reach but cannot *list* calendars, so the connector hardcoded `calendarId="primary"`.

**Frontend:** `GOOGLE_SCOPES` gains `calendar.calendarlist.readonly`. Read only, names calendars, nothing else; `calendar` and `calendar.readonly` were rejected as too broad (doc 17's rule holds). `data/access.ts` and the seed script are brought in line; the seed script had drifted badly (still asked for `calendar` and `drive.file`).

**Connector (@MatthewA15, please review the Python):** contract v0.7, all additive.
- `GET /calendar/calendars` is new: every readable calendar, primary first, with `access_role`.
- `GET /calendar/events` gains `calendar_id` (default `primary`) and `all_calendars` (merge across every calendar, sorted by parsed start across offsets, capped at `max_results`). Every event now carries `calendar_id` and `calendar_summary`.
- `POST /calendar/events` accepts `calendar_id`.
- 403 from `calendarList` surfaces as "re-consent", same shape as `drive.py`.
- `tests/test_calendar_router.py`: the default read never touches `calendarList`, merge order, cap, skipping an unshared calendar, the reconsent 403, and the POST default.

It is in a frontend PR because the scope change is inert without it and the change is small. Happy to split it out if you would rather own it.

**Re-consent is required** for anyone who granted before this. `primary` keeps working on the old token; only `/calendars` and `all_calendars=true` return 403 until they press Reconnect on `/dashboard/access`.

**The sync rule expired underneath this.** `googleOAuth.ts`, docs 12 and 17, and `ENCRYPTION_CONTRACT.md` §7 all said `GOOGLE_SCOPES` had to match a list in the connector's `app/config.py`. That list has not existed since contract v0.5. The comments and §7 now say the frontend is the sole owner.

## Verification

- `npm run typecheck`: clean. `npm run build`: clean, `/portal-login` in the route table, `/onboarding` route JS 16.6 kB → 13.5 kB. `npm test`: 11/11.
- Connector: `pytest tests/`: 86 passed, 1 pre-existing skip (Python 3.12 venv).
- `next lint` is not configured in this repo (it prompts for setup), so no lint pass was run.
- Not driven in a browser against a real SMS; the phone step itself is unchanged.

## Outside the repo, when relevant

If the OAuth app is ever verified, the new scope has to be declared on the consent screen in the Console. In testing mode nothing needs changing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
